### PR TITLE
Rename Gen/Property with T and add alias for syntax

### DIFF
--- a/core/src/main/scala/hedgehog/Gen.scala
+++ b/core/src/main/scala/hedgehog/Gen.scala
@@ -38,11 +38,11 @@ case class GenT[M[_], A](run: (Size, Seed) => Tree[M, (Seed, Option[A])]) {
   /**********************************************************************/
   // Combinators - Property
 
-  def log(name: Name)(implicit F: Monad[M]): Property[M, A] =
+  def log(name: Name)(implicit F: Monad[M]): PropertyT[M, A] =
     for {
-      x <- Property.fromGen(this)
+      x <- propertyT.fromGen(this)
       // TODO Add better render, although I don't really like Show
-      _ <- Property.writeLog[M](ForAll(name, x.toString))
+      _ <- propertyT[M].writeLog(ForAll(name, x.toString))
     } yield x
 
   /**********************************************************************/
@@ -215,11 +215,3 @@ trait GenTOps[M[_]] {
   def discard[A](implicit F: Applicative[M]): GenT[M, A] =
     GenT((_, seed) => Tree.TreeApplicative(F).point((seed, None)))
 }
-
-/**
- * This is _purely_ to make consuming this library a nicer experience,
- * mainly due to Scala's type inference problems and higher kinds.
- *
- * NOTE: GenT needs to be trampolined as well.
- */
-object Gen extends GenTOps[scalaz.effect.IO]

--- a/core/src/main/scala/hedgehog/Gen.scala
+++ b/core/src/main/scala/hedgehog/Gen.scala
@@ -5,18 +5,18 @@ import scalaz._, Scalaz._
 /**
  * Generator for random values of `A`.
  */
-case class Gen[M[_], A](run: (Size, Seed) => Tree[M, (Seed, Option[A])]) {
+case class GenT[M[_], A](run: (Size, Seed) => Tree[M, (Seed, Option[A])]) {
 
-  def map[B](f: A => B)(implicit F: Functor[M]): Gen[M, B] =
-    Gen((size, seed) => run(size, seed).map(_.map(_.map(f))))
+  def map[B](f: A => B)(implicit F: Functor[M]): GenT[M, B] =
+    GenT((size, seed) => run(size, seed).map(_.map(_.map(f))))
 
-  def flatMap[B](f: A => Gen[M, B])(implicit F: Monad[M]): Gen[M, B] =
-    Gen((size, seed) => run(size, seed).flatMap(x =>
+  def flatMap[B](f: A => GenT[M, B])(implicit F: Monad[M]): GenT[M, B] =
+    GenT((size, seed) => run(size, seed).flatMap(x =>
       x._2.cata(a => f(a).run(size, x._1), Tree.TreeApplicative(F).point(x.as(none)))
     ))
 
-  def mapTree[N[_], B](f: Tree[M, (Seed, Option[A])] => Tree[N, (Seed, Option[B])]): Gen[N, B] =
-    Gen((size, seed) => f(run(size, seed)))
+  def mapTree[N[_], B](f: Tree[M, (Seed, Option[A])] => Tree[N, (Seed, Option[B])]): GenT[N, B] =
+    GenT((size, seed) => f(run(size, seed)))
 
   /**********************************************************************/
   // Shrinking
@@ -24,7 +24,7 @@ case class Gen[M[_], A](run: (Size, Seed) => Tree[M, (Seed, Option[A])]) {
   /**
    * Apply a shrinking function to a generator.
    */
-  def shrink(f: A => List[A])(implicit F: Monad[M]): Gen[M, A] =
+  def shrink(f: A => List[A])(implicit F: Monad[M]): GenT[M, A] =
     mapTree(_.expand(x =>
       x._2.cata(a => f(a).map(y => (x._1, Some(y))), Nil)
     ))
@@ -32,7 +32,7 @@ case class Gen[M[_], A](run: (Size, Seed) => Tree[M, (Seed, Option[A])]) {
   /**
    * Throw away a generator's shrink tree.
    */
-  def prune(implicit F: Monad[M]): Gen[M, A] =
+  def prune(implicit F: Monad[M]): GenT[M, A] =
     mapTree(_.prune)
 
   /**********************************************************************/
@@ -52,49 +52,49 @@ case class Gen[M[_], A](run: (Size, Seed) => Tree[M, (Seed, Option[A])]) {
    * Override the size parameter. Returns a generator which uses the given size
    * instead of the runtime-size parameter.
    */
-  def resize(size: Size): Gen[M, A] =
+  def resize(size: Size): GenT[M, A] =
     if (size.value < 0)
       sys.error("Hedgehog.Random.resize: negative size")
     else
-      Gen((_, seed) => run(size, seed))
+      GenT((_, seed) => run(size, seed))
 
   /**
    * Adjust the size parameter by transforming it with the given function.
    */
-  def scale(f: Size => Size): Gen[M, A] =
-    Gen.sized(n => resize(f(n)))
+  def scale(f: Size => Size): GenT[M, A] =
+    genT.sized(n => resize(f(n)))
 
   /**
    * Make a generator smaller by scaling its size parameter.
    */
-  def small: Gen[M, A] =
+  def small: GenT[M, A] =
     scale(_.golden)
 
   /**********************************************************************/
   // Combinators
 
-  def list(range: Range[Int])(implicit F: Monad[M]): Gen[M, List[A]] =
+  def list(range: Range[Int])(implicit F: Monad[M]): GenT[M, List[A]] =
     // TODO filterM, needs a MonadPlus for Gen
-    Gen.integral_[M, Int](range).flatMap(k => this.replicateM(k))
+    genT[M].integral_[Int](range).flatMap(k => this.replicateM(k))
       .shrink(Shrink.list)
 }
 
 abstract class GenImplicits1 {
 
-  implicit def GenFunctor[M[_]](implicit F: Functor[M]): Functor[Gen[M, ?]] =
-    new Functor[Gen[M, ?]] {
-      override def map[A, B](fa: Gen[M, A])(f: A => B): Gen[M, B] =
+  implicit def GenFunctor[M[_]](implicit F: Functor[M]): Functor[GenT[M, ?]] =
+    new Functor[GenT[M, ?]] {
+      override def map[A, B](fa: GenT[M, A])(f: A => B): GenT[M, B] =
         fa.map(f)
     }
 }
 
 abstract class GenImplicits2 extends GenImplicits1 {
 
-  implicit def GenApplicative[M[_]](implicit F: Monad[M]): Applicative[Gen[M, ?]] =
-    new Applicative[Gen[M, ?]] {
-      def point[A](a: => A): Gen[M, A] =
-        Gen((_, s) => Tree.TreeApplicative(F).point((s, Some(a))))
-      def ap[A, B](fa: => Gen[M, A])(f: => Gen[M, A => B]): Gen[M, B] =
+  implicit def GenApplicative[M[_]](implicit F: Monad[M]): Applicative[GenT[M, ?]] =
+    new Applicative[GenT[M, ?]] {
+      def point[A](a: => A): GenT[M, A] =
+        GenT((_, s) => Tree.TreeApplicative(F).point((s, Some(a))))
+      def ap[A, B](fa: => GenT[M, A])(f: => GenT[M, A => B]): GenT[M, B] =
         for {
           ab <- f
           a <- fa
@@ -102,7 +102,10 @@ abstract class GenImplicits2 extends GenImplicits1 {
     }
 }
 
-object Gen extends GenImplicits2 {
+object GenT extends GenImplicits2 {
+}
+
+trait GenTOps[M[_]] {
 
   /**********************************************************************/
   // Combinators - Size
@@ -110,8 +113,8 @@ object Gen extends GenImplicits2 {
   /**
    * Construct a generator that depends on the size parameter.
    */
-  def sized[M[_], A](f: Size => Gen[M, A]): Gen[M, A] =
-    Gen((size, seed) => f(size).run(size, seed))
+  def sized[A](f: Size => GenT[M, A]): GenT[M, A] =
+    GenT((size, seed) => f(size).run(size, seed))
 
   /**********************************************************************/
   // Combinators - Integral
@@ -152,36 +155,36 @@ object Gen extends GenImplicits2 {
    * 2060
    * }}}
    */
-  def integral[M[_] : Monad, A : Integral](range: Range[A]): Gen[M, A] =
-    integral_[M, A](range).shrink(Shrink.towards(range.origin, _))
+  def integral[A : Integral](range: Range[A])(implicit F: Monad[M]): GenT[M, A] =
+    integral_[A](range).shrink(Shrink.towards(range.origin, _))
 
   /**
    * Generates a random integral number in the `[inclusive,inclusive]` range.
    *
    * ''This generator does not shrink.''
    */
-  def integral_[M[_], A](range: Range[A])(implicit F: Monad[M], I: Integral[A]): Gen[M, A] =
-    Gen((size, seed) => {
+  def integral_[A](range: Range[A])(implicit F: Monad[M], I: Integral[A]): GenT[M, A] =
+    GenT((size, seed) => {
       val (x, y) = range.bounds(size)
       val (s2, a) = seed.chooseLong(I.toLong(x), I.toLong(y))
       // TODO Integral doesn't support Long, can we only use int seeds? :(
-      I.fromInt(a.toInt).point[Gen[M, ?]].run(size, s2)
+      I.fromInt(a.toInt).point[GenT[M, ?]].run(size, s2)
     })
 
-  def char[M[_] : Monad](lo: Char, hi: Char): Gen[M, Char] =
-    integral[M, Long](Range.constant(lo.toLong, hi.toLong)).map(_.toChar)
+  def char(lo: Char, hi: Char)(implicit F: Monad[M]): GenT[M, Char] =
+    integral[Long](Range.constant(lo.toLong, hi.toLong)).map(_.toChar)
 
   /**********************************************************************/
   // Combinators - Fractional
 
-  def double[M[_] : Monad](range: Range[Double]): Gen[M, Double] =
-    double_[M](range).shrink(Shrink.towardsFloat(range.origin, _))
+  def double(range: Range[Double])(implicit F: Monad[M]): GenT[M, Double] =
+    double_(range).shrink(Shrink.towardsFloat(range.origin, _))
 
-  def double_[M[_]](range: Range[Double])(implicit F: Monad[M]): Gen[M, Double] =
-    Gen((size, seed) => {
+  def double_(range: Range[Double])(implicit F: Monad[M]): GenT[M, Double] =
+    GenT((size, seed) => {
       val (x, y) = range.bounds(size)
       val (s2, a) = seed.chooseDouble(x, y)
-      a.point[Gen[M, ?]].run(size, s2)
+      a.point[GenT[M, ?]].run(size, s2)
     })
 
   /**********************************************************************/
@@ -192,16 +195,16 @@ object Gen extends GenImplicits2 {
    *
    * This generator shrinks towards the first element in the list.
    */
-  def element[M[_] : Monad, A](x: A, xs: List[A]): Gen[M, A] =
-    integral[M, Int](Range.constant(0, xs.length)).map(i => (x :: xs)(i))
+  def element[A](x: A, xs: List[A])(implicit F: Monad[M]): GenT[M, A] =
+    integral[Int](Range.constant(0, xs.length)).map(i => (x :: xs)(i))
 
   /**
    * Randomly selects one of the generators in the list.
    *
    * This generator shrinks towards the first generator in the list.
    */
-  def choice[M[_] : Monad, A](x: Gen[M, A], xs: List[Gen[M, A]]): Gen[M, A] =
-    integral[M, Int](Range.constant(0, xs.length)).flatMap(i => (x :: xs)(i))
+  def choice[A](x: GenT[M, A], xs: List[GenT[M, A]])(implicit F: Monad[M]): GenT[M, A] =
+    integral[Int](Range.constant(0, xs.length)).flatMap(i => (x :: xs)(i))
 
   /**********************************************************************/
   // Combinators - Conditional
@@ -209,6 +212,14 @@ object Gen extends GenImplicits2 {
   /**
    * Discards the whole generator.
    */
-  def discard[M[_], A](implicit F: Applicative[M]): Gen[M, A] =
-    Gen((_, seed) => Tree.TreeApplicative(F).point((seed, None)))
+  def discard[A](implicit F: Applicative[M]): GenT[M, A] =
+    GenT((_, seed) => Tree.TreeApplicative(F).point((seed, None)))
 }
+
+/**
+ * This is _purely_ to make consuming this library a nicer experience,
+ * mainly due to Scala's type inference problems and higher kinds.
+ *
+ * NOTE: GenT needs to be trampolined as well.
+ */
+object Gen extends GenTOps[scalaz.effect.IO]

--- a/core/src/main/scala/hedgehog/Property.scala
+++ b/core/src/main/scala/hedgehog/Property.scala
@@ -16,13 +16,13 @@ sealed trait Log
 case class ForAll(name: Name, value: String) extends Log
 case class Info(value: String) extends Log
 
-case class Property[M[_], A](run: GenT[M, (List[Log], Option[A])]) {
+case class PropertyT[M[_], A](run: GenT[M, (List[Log], Option[A])]) {
 
-  def map[B](f: A => B)(implicit F: Functor[M]): Property[M, B] =
-    Property(run.map(_.map(_.map(f))))
+  def map[B](f: A => B)(implicit F: Functor[M]): PropertyT[M, B] =
+    PropertyT(run.map(_.map(_.map(f))))
 
-  def flatMap[B](f: A => Property[M, B])(implicit F: Monad[M]): Property[M, B] =
-    Property(run.flatMap(x =>
+  def flatMap[B](f: A => PropertyT[M, B])(implicit F: Monad[M]): PropertyT[M, B] =
+    PropertyT(run.flatMap(x =>
       x._2.cata(
         a => f(a).run.map(y => (x._1 ++ y._1, y._2))
       , GenT.GenApplicative(F).point((x._1, None))
@@ -30,55 +30,58 @@ case class Property[M[_], A](run: GenT[M, (List[Log], Option[A])]) {
     ))
 
   def check(seed: Seed)(implicit F: Monad[M]): M[Report] =
-    Property.report(SuccessCount(100), Size(0), seed, this)
+    propertyT.report(SuccessCount(100), Size(0), seed, this)
 
-  def checkRandom(p: Property[M, Unit])(implicit F: MonadIO[M]): M[Report] =
+  def checkRandom(p: PropertyT[M, Unit])(implicit F: MonadIO[M]): M[Report] =
     Seed.fromTime.liftIO.flatMap(s => check(s))
 }
 
-object Property {
+object PropertyT {
 
-  implicit def PropertyMonad[M[_]](implicit F: Monad[M]): Monad[Property[M, ?]] =
-    new Monad[Property[M, ?]] {
-      override def map[A, B](fa: Property[M, A])(f: A => B): Property[M, B] =
+  implicit def PropertyMonad[M[_]](implicit F: Monad[M]): Monad[PropertyT[M, ?]] =
+    new Monad[PropertyT[M, ?]] {
+      override def map[A, B](fa: PropertyT[M, A])(f: A => B): PropertyT[M, B] =
         fa.map(f)
-      override def point[A](a: => A): Property[M, A] =
-        hoist((Nil, a))
-      override def bind[A, B](fa: Property[M, A])(f: A => Property[M, B]): Property[M, B] =
+      override def point[A](a: => A): PropertyT[M, A] =
+        propertyT.hoist((Nil, a))
+      override def bind[A, B](fa: PropertyT[M, A])(f: A => PropertyT[M, B]): PropertyT[M, B] =
         fa.flatMap(f)
     }
+}
 
-  def fromGen[M[_] : Monad, A](gen: GenT[M, A]): Property[M, A] =
-    Property(gen.map(x => (Nil, Some(x))))
+trait PropertyTOps[M[_]] {
 
-  def hoist[M[_], A](a: (List[Log], A))(implicit F: Monad[M]): Property[M, A] =
-    Property(GenT.GenApplicative(F).point(a.map(some)))
+  def fromGen[A](gen: GenT[M, A])(implicit F: Monad[M]): PropertyT[M, A] =
+    PropertyT(gen.map(x => (Nil, Some(x))))
 
-  def writeLog[M[_] : Monad](log: Log): Property[M, Unit] =
+  def hoist[A](a: (List[Log], A))(implicit F: Monad[M]): PropertyT[M, A] =
+    PropertyT(GenT.GenApplicative(F).point(a.map(some)))
+
+  def writeLog(log: Log)(implicit F: Monad[M]): PropertyT[M, Unit] =
     hoist((List(log), ()))
 
-  def info[M[_] : Monad](log: String): Property[M, Unit] =
+  def info(log: String)(implicit F: Monad[M]): PropertyT[M, Unit] =
     writeLog(Info(log))
 
-  def discard[M[_] : Monad]: Property[M, Unit] =
+  def discard(implicit F: Monad[M]): PropertyT[M, Unit] =
     fromGen(genT.discard)
 
-  def failure[M[_], A](implicit F: Monad[M]): Property[M, A] =
-    Property(GenT.GenApplicative(F).point((Nil, None)))
+  def failure[A](implicit F: Monad[M]): PropertyT[M, A] =
+    PropertyT(GenT.GenApplicative(F).point((Nil, None)))
 
-  def success[M[_] : Monad]: Property[M, Unit] =
+  def success(implicit F: Monad[M]): PropertyT[M, Unit] =
     hoist((Nil, ()))
 
-  def assert[M[_] : Monad](b: Boolean): Property[M, Unit] =
+  def assert(b: Boolean)(implicit F: Monad[M]): PropertyT[M, Unit] =
     if (b) success else failure
 
   /**********************************************************************/
   // Reporting
 
-  def isFailure[M[_], A, B](n: Node[M, Option[(B, Option[A])]]): Boolean =
+  def isFailure[A, B](n: Node[M, Option[(B, Option[A])]]): Boolean =
     n.value.map(_._2) == Some(None)
 
-  def takeSmallest[M[_] : Monad, A](n: ShrinkCount, t: Node[M, Option[(List[Log], Option[A])]]): M[Status] =
+  def takeSmallest[A](n: ShrinkCount, t: Node[M, Option[(List[Log], Option[A])]])(implicit F: Monad[M]): M[Status] =
     t.value match {
       case None =>
         Status.gaveUp.point[M]
@@ -98,7 +101,7 @@ object Property {
         Status.ok.point[M]
     }
 
-  def report[M[_] : Monad, A](n : SuccessCount, size0: Size, seed0: Seed, p: Property[M, A]): M[Report] = {
+  def report[A](n : SuccessCount, size0: Size, seed0: Seed, p: PropertyT[M, A])(implicit F: Monad[M]): M[Report] = {
     def loop(successes: SuccessCount, discards: DiscardCount, size: Size, seed: Seed): M[Report] =
       if (size.value > 99)
         loop(successes, discards, Size(0), seed)
@@ -122,7 +125,7 @@ object Property {
     loop(SuccessCount(0), DiscardCount(0), size0, seed0)
   }
 
-  def recheck[M[_] : Monad](size: Size, seed: Seed)(p: Property[M, Unit]): M[Report] =
+  def recheck(size: Size, seed: Seed)(p: PropertyT[M, Unit])(implicit F: Monad[M]): M[Report] =
     report(SuccessCount(1), Size(0), seed, p)
 }
 

--- a/core/src/main/scala/hedgehog/package.scala
+++ b/core/src/main/scala/hedgehog/package.scala
@@ -1,0 +1,7 @@
+package object hedgehog {
+
+  type Gen[A] = GenT[scalaz.effect.IO, A]
+
+  def genT[M[_]]: GenTOps[M] =
+    new GenTOps[M] {}
+}

--- a/core/src/main/scala/hedgehog/package.scala
+++ b/core/src/main/scala/hedgehog/package.scala
@@ -1,19 +1,19 @@
 package object hedgehog {
 
+  type HM[A] = scalaz.Scalaz.Identity[A]
+
   /**
    * This is _purely_ to make consuming this library a nicer experience,
    * mainly due to Scala's type inference problems and higher kinds.
-   *
-   * NOTE: GenT needs to be trampolined as well.
    */
-  object Gen extends GenTOps[scalaz.effect.IO]
-  type Gen[A] = GenT[scalaz.effect.IO, A]
+  object Gen extends GenTOps[HM]
+  type Gen[A] = GenT[HM, A]
 
   def genT[M[_]]: GenTOps[M] =
     new GenTOps[M] {}
 
-  type Property[A] = PropertyT[scalaz.effect.IO, A]
-  object Property extends PropertyTOps[scalaz.effect.IO]
+  type Property[A] = PropertyT[HM, A]
+  object Property extends PropertyTOps[HM]
 
   def propertyT[M[_]]: PropertyTOps[M] =
     new PropertyTOps[M] {}

--- a/core/src/main/scala/hedgehog/package.scala
+++ b/core/src/main/scala/hedgehog/package.scala
@@ -1,7 +1,20 @@
 package object hedgehog {
 
+  /**
+   * This is _purely_ to make consuming this library a nicer experience,
+   * mainly due to Scala's type inference problems and higher kinds.
+   *
+   * NOTE: GenT needs to be trampolined as well.
+   */
+  object Gen extends GenTOps[scalaz.effect.IO]
   type Gen[A] = GenT[scalaz.effect.IO, A]
 
   def genT[M[_]]: GenTOps[M] =
     new GenTOps[M] {}
+
+  type Property[A] = PropertyT[scalaz.effect.IO, A]
+  object Property extends PropertyTOps[scalaz.effect.IO]
+
+  def propertyT[M[_]]: PropertyTOps[M] =
+    new PropertyTOps[M] {}
 }

--- a/core/src/test/scala/hedgehog/PropertyTest.scala
+++ b/core/src/test/scala/hedgehog/PropertyTest.scala
@@ -4,7 +4,6 @@ import hedgehog.Gen._
 import hedgehog.Property._
 import org.scalacheck.{Gen => _, _}
 import org.scalacheck.Prop._
-import scalaz.effect._
 
 object PropertyTest extends Properties("Property") {
 
@@ -13,8 +12,8 @@ object PropertyTest extends Properties("Property") {
     val r = (for {
       x <- Gen.char('a', 'z').log("x")
       y <- integral(Range.linear(0, 50)).log("y")
-      _ <- if (y % 2 == 0) Property.discard[IO] else success[IO]
-      _ <- assert[IO](y < 87 && x <= 'r')
+      _ <- if (y % 2 == 0) Property.discard else success
+      _ <- assert(y < 87 && x <= 'r')
     } yield ()).check(seed).unsafePerformIO
     r ?= Report(SuccessCount(0), DiscardCount(2), Failed(ShrinkCount(1), List(
         ForAll("x", "s")
@@ -59,7 +58,7 @@ object PropertyTest extends Properties("Property") {
     val r = (for {
       x <- order(cheap).log("cheap")
       y <- order(expensive).log("expensive")
-      _ <- assert[IO](merge(x, y).total.value == x.total.value + y.total.value)
+      _ <- assert(merge(x, y).total.value == x.total.value + y.total.value)
     } yield ()).check(seed).unsafePerformIO
     r ?= Report(SuccessCount(3), DiscardCount(0), Failed(ShrinkCount(5), List(
         ForAll("cheap", "Order(List())")

--- a/core/src/test/scala/hedgehog/PropertyTest.scala
+++ b/core/src/test/scala/hedgehog/PropertyTest.scala
@@ -32,7 +32,7 @@ object PropertyTest extends Properties("Property") {
   def merge(xs: Order, ys: Order): Order = {
     val extra =
       if (xs.items.exists(_.price.value > 50) || ys.items.exists(_.price.value > 50) )
-        List(Item("processing", (USD(1))))
+        List(Item("processing", USD(1)))
       else
         Nil
     Order(xs.items ++ ys.items ++ extra)

--- a/core/src/test/scala/hedgehog/PropertyTest.scala
+++ b/core/src/test/scala/hedgehog/PropertyTest.scala
@@ -14,7 +14,7 @@ object PropertyTest extends Properties("Property") {
       y <- integral(Range.linear(0, 50)).log("y")
       _ <- if (y % 2 == 0) Property.discard else success
       _ <- assert(y < 87 && x <= 'r')
-    } yield ()).check(seed).unsafePerformIO
+    } yield ()).check(seed).value
     r ?= Report(SuccessCount(0), DiscardCount(2), Failed(ShrinkCount(1), List(
         ForAll("x", "s")
       , ForAll("y", "1"))
@@ -59,7 +59,7 @@ object PropertyTest extends Properties("Property") {
       x <- order(cheap).log("cheap")
       y <- order(expensive).log("expensive")
       _ <- assert(merge(x, y).total.value == x.total.value + y.total.value)
-    } yield ()).check(seed).unsafePerformIO
+    } yield ()).check(seed).value
     r ?= Report(SuccessCount(3), DiscardCount(0), Failed(ShrinkCount(5), List(
         ForAll("cheap", "Order(List())")
       , ForAll("expensive", "Order(List(Item(oculus,USD(1000))))"


### PR DESCRIPTION
This is almost certainly not the best way of doing this, but at least makes it usable for consumers until we have a better way (or just hard-code the monad in the data type)