### PR TITLE
Stop looping during the report when nothing is generated

### DIFF
--- a/core/src/main/scala/hedgehog/core/PropertyT.scala
+++ b/core/src/main/scala/hedgehog/core/PropertyT.scala
@@ -120,8 +120,12 @@ trait PropertyTReporting[M[_]] {
             case Some((_, None)) =>
               F.map(takeSmallest(ShrinkCount(0), p.config.shrinkLimit, x.map(_._2)))(y => Report(successes, discards, y))
 
-            case Some((m, Some(_))) =>
-              loop(successes.inc, discards, size.inc, x.value._1)
+            case Some((_, Some(_))) =>
+              // Stop looping if the seed was never used - the property never generated anything
+              if (seed == x.value._1)
+                F.point(Report(successes.inc, discards, OK))
+              else
+                loop(successes.inc, discards, size.inc, x.value._1)
           }
         )
     loop(SuccessCount(0), DiscardCount(0), size0, seed0)


### PR DESCRIPTION
/cc @jystic @moodmosaic @thumphries 

For people using hedgehog as the only test runner, it's a little confusing/deceiving having "passed 100 tests" when it's technically only run once.

I've seen ScalaCheck do this too, but it tracks a "proof" result differently from "passed", which is quite different. I'm still not entirely sure how it works though.

I also realise that this wouldn't currently be possible with the same mechanism as haskell-hedgehog due to not having access to the final seed.

Thoughts on whether this is
a) a good idea
b) the best way to implement it