### PR TITLE
Support Scala 2.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: scala
 scala:
+ - 2.10.4
  - 2.11.12
- - 2.12.6
+ - 2.12.7
 script:
   - sbt ++$TRAVIS_SCALA_VERSION 'set version in ThisBuild := "'$(git log --format=%H -1)'"' test
 after_success:

--- a/build.sbt
+++ b/build.sbt
@@ -25,8 +25,8 @@ lazy val projectSettings = Seq(
     name := "hedgehog"
   , version in ThisBuild := "1.0.0"
   , organization := "hedgehog"
-  , scalaVersion := "2.12.6"
-  , crossScalaVersions := Seq("2.11.12", scalaVersion.value)
+  , scalaVersion := "2.12.7"
+  , crossScalaVersions := Seq("2.10.7", "2.11.12", scalaVersion.value)
   , fork in run  := true
   )
 
@@ -87,7 +87,13 @@ lazy val compilationSettings = Seq(
     , "-Yno-adapted-args"
     , "-Xlint"
     , "-Xfatal-warnings"
-    , "-Ywarn-unused-import"
+    ) ++ (
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, 10)) =>
+          Seq.empty
+        case _ =>
+          Seq("-Ywarn-unused-import")
+      }
     )
   , scalacOptions in (Compile,console) := Seq("-language:_", "-feature")
   , scalacOptions in (Test,console) := Seq("-language:_", "-feature")


### PR DESCRIPTION
It would be really nice to have Scala 2.10 support for SBT plugin projects targeting SBT 0.13 as it supports only Scala 2.10.

Unfortunately, I couldn't test it in my sbt plugin project because an SBT subproject doesn't work well with sbt-cross-building. More precisely, if I run `^compile` or `^test`, it seems to ignore the subprojects and try to get it from the repositories. So I think it needs to be released for actual use.