### PR TITLE
Change property to force result as final value

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ As a general rule, the current Scala API is intended to be _direct_ port of
 [scalacheck](https://github.com/rickynils/scalacheck) was for [QuickCheck](http://hackage.haskell.org/package/QuickCheck).
 The idea being that people familiar with one of the libraries will be comfortable with the other.
 It also makes it easier not having to re-invent any wheels (or APIs).
-There will obviously be exceptions where Scala forces us to make a different trade-off, such as the
-[Gen](core/src/main/scala/hedgehog/Gen.scala) type alias of `GenT` to assist with type-inference.
+There will obviously be exceptions where Scala forces us to make a different trade-off.
+See [haskell-differences](doc/haskell-differences.md) for examples and more explanation.
 
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ object PropertyTest extends Properties {
       Prop("reverse", testReverse)
     )
 
-  def testReverse: Property[Unit] =
+  def testReverse: Property =
     for {
       xs <- Gen.alpha.list(Range.linear(0, 100)).forAll
       _ <- xs.reverse.reverse === xs

--- a/README.md
+++ b/README.md
@@ -117,8 +117,7 @@ object PropertyTest extends Properties {
   def testReverse: Property =
     for {
       xs <- Gen.alpha.list(Range.linear(0, 100)).forAll
-      _ <- xs.reverse.reverse === xs
-    } yield ()
+    } yield xs.reverse.reverse === xs
 }
 ```
 

--- a/core/src/main/scala/hedgehog/core/Result.scala
+++ b/core/src/main/scala/hedgehog/core/Result.scala
@@ -1,0 +1,89 @@
+package hedgehog.core
+
+import hedgehog._
+
+sealed trait Result {
+
+  import Result._
+
+  def success: Boolean =
+    this match {
+      case Success =>
+        true
+      case Failure(_) =>
+        false
+    }
+
+  def logs: List[Log] =
+    this match {
+      case Success =>
+        Nil
+      case Failure(l) =>
+        l
+    }
+
+  def and(other: Result): Result =
+    this match {
+      case Success =>
+        other
+      case Failure(logs) =>
+        other match {
+          case Success =>
+            Failure(logs)
+          case Failure(logs2) =>
+            Failure(logs ++ logs2)
+        }
+    }
+
+  def or(other: Result): Result =
+    this match {
+      case Success =>
+        other
+      case Failure(logs) =>
+        other match {
+          case Success =>
+            Success
+          case Failure(logs2) =>
+            Failure(logs ++ logs2)
+        }
+    }
+
+  def log(info: Log): Result =
+    this match {
+      case Success =>
+        Success
+      case Failure(l) =>
+        Failure(l ++ List(info))
+    }
+
+  def property: Property =
+    Property.point(this)
+      // By default run once
+      // This is related to:
+      // https://github.com/hedgehogqa/scala-hedgehog/pull/35
+      .withTests(SuccessCount(1))
+}
+
+object Result {
+
+  case object Success extends Result
+  case class Failure(log: List[Log]) extends Result
+
+  def success: Result =
+    Success
+
+  def failure: Result =
+    Failure(Nil)
+
+  def error(e: Exception): Result =
+    failure.log(Error(e))
+
+  def assert(b: Boolean): Result =
+    if (b) success else failure
+
+  def all(l: List[Result]): Result =
+    l.foldLeft(Result.success)(_.and(_))
+
+  def any(l: List[Result]): Result =
+    l.foldLeft(Result.failure)(_.or(_))
+}

--- a/core/src/main/scala/hedgehog/package.scala
+++ b/core/src/main/scala/hedgehog/package.scala
@@ -22,8 +22,11 @@ package object hedgehog {
     with CharacterOps[M]
     with StringOps[M] {}
 
-  type Property = PropertyT[HM, Unit]
+  type Property = PropertyT[HM, Result]
   object Property extends PropertyTOps[HM]
+
+  type Result = hedgehog.core.Result
+  val Result = hedgehog.core.Result
 
   def propertyT[M[_]]: PropertyTOps[M] =
     new PropertyTOps[M] {}
@@ -31,21 +34,18 @@ package object hedgehog {
   implicit class Syntax[A](a1: A) {
 
      // FIX Is there a way to get this to work with PropertyT and type-inference?
-     def ===(a2: A): Property = {
-       val p = Property
+     def ===(a2: A): Result = {
        if (a1 == a2)
-         p.success
+         Result.success
        else
-         for {
-           _ <- p.info("=== Not Equal ===")
-           _ <- p.info(a1.toString)
-           _ <- p.info(a2.toString)
-           _ <- p.failure
-         } yield ()
+         Result.failure
+           .log("=== Not Equal ===")
+           .log(a1.toString)
+           .log(a2.toString)
      }
 
     // To avoid name clashes
-    def ====(a2: A): Property =
+    def ====(a2: A): Result =
       ===(a2)
   }
 }

--- a/core/src/main/scala/hedgehog/package.scala
+++ b/core/src/main/scala/hedgehog/package.scala
@@ -22,7 +22,7 @@ package object hedgehog {
     with CharacterOps[M]
     with StringOps[M] {}
 
-  type Property[A] = PropertyT[HM, A]
+  type Property = PropertyT[HM, Unit]
   object Property extends PropertyTOps[HM]
 
   def propertyT[M[_]]: PropertyTOps[M] =
@@ -31,7 +31,7 @@ package object hedgehog {
   implicit class Syntax[A](a1: A) {
 
      // FIX Is there a way to get this to work with PropertyT and type-inference?
-     def ===(a2: A): Property[Unit] = {
+     def ===(a2: A): Property = {
        val p = Property
        if (a1 == a2)
          p.success
@@ -45,7 +45,7 @@ package object hedgehog {
      }
 
     // To avoid name clashes
-    def ====(a2: A): Property[Unit] =
+    def ====(a2: A): Property =
       ===(a2)
   }
 }

--- a/doc/haskell-differences.md
+++ b/doc/haskell-differences.md
@@ -1,0 +1,62 @@
+Differences to Haskell Hedgehog
+===============================
+
+This page documents where the Scala Hedgehog API deviates significantly from the Haskell version.
+
+
+## Result
+
+The Haskell version allow for assertions throughout the `Property` monad, but the final value is
+[()](https://github.com/hedgehogqa/haskell-hedgehog/blob/694d3648f808d2401834c3e75db24b960ee8a68c/hedgehog/src/Hedgehog/Internal/Property.hs#L133).
+
+```haskell
+prop_reverse :: Property
+prop_reverse =
+  property $ do
+    xs <- forAll $ Gen.list (Range.linear 0 100) Gen.alpha
+    reverse (reverse xs) === xs
+```
+
+And the corresponding Scala version:
+
+```scala
+def propReverse: Property =
+  for {
+    xs <- Gen.alpha.list(Range.linear(0, 100)).forAll
+  } yield xs.reverse.reverse === xs
+```
+
+### Resource Management
+
+This approach makes it more difficult to isolate resource management in a strict language like Scala.
+It then becomes fairly important in the Haskell version to use
+[ResourceT](https://github.com/hedgehogqa/haskell-hedgehog/blob/master/hedgehog-example/src/Test/Example/Resource.hs):
+
+```haskell
+prop_unix_sort :: Property
+prop_unix_sort =
+  property $ do
+    values0 <- forAll $ Gen.list (Range.linear 0 100) Gen.alpha
+    test . runResourceT $ do
+      dir <- Temp.createTempDirectory Nothing "prop_dir"
+      ...
+      values0 === values
+```
+
+To simplify this, and to reduce surprises, the final result in the Scala version is now a separate
+[Result](https://github.com/hedgehogqa/scala-hedgehog/blob/master/core/src/main/scala/hedgehog/core/Result.scala) value,
+which forces a single, final assertion to be returned.
+
+```scala
+def propUnixSort: Property =
+  for {
+    values0 <- Gen.alpha.list(Range.linear(0, 100)).forAll
+  } yield {
+    val dir = java.io.Files.createTempDirectory(getClass.getSimpleName).toFile
+    try {
+      values0 === values
+    } finally {
+      dir.delete()
+    }
+  }
+```

--- a/example/src/test/scala/hedgehog/example/PropertyTest.scala
+++ b/example/src/test/scala/hedgehog/example/PropertyTest.scala
@@ -2,7 +2,6 @@ package hedgehog.example
 
 import hedgehog._
 import hedgehog.Gen._
-import hedgehog.Property._
 import hedgehog.runner._
 
 object PropertyTest extends Properties {
@@ -17,16 +16,14 @@ object PropertyTest extends Properties {
     for {
       x <- Gen.char('a', 'z').log("x")
       y <- int(Range.linear(0, 50)).lift
-      _ <- if (y % 2 == 0) Property.discard else success
-      _ <- assert(y < 87 && x <= 'r')
-    } yield ()
+      _ <- if (y % 2 == 0) Property.discard else Property.point(())
+    } yield Result.assert(y < 87 && x <= 'r')
 
   def total: Property =
     for {
       x <- order(cheap).log("cheap")
       y <- order(expensive).log("expensive")
-      _ <- merge(x, y).total.value === x.total.value + y.total.value
-    } yield ()
+    } yield merge(x, y).total.value === x.total.value + y.total.value
 
   case class USD(value: Long)
   case class Item(name: String, price: USD)

--- a/example/src/test/scala/hedgehog/example/PropertyTest.scala
+++ b/example/src/test/scala/hedgehog/example/PropertyTest.scala
@@ -13,7 +13,7 @@ object PropertyTest extends Properties {
     , Prop("total", total)
     )
 
-  def example1: Property[Unit] =
+  def example1: Property =
     for {
       x <- Gen.char('a', 'z').log("x")
       y <- int(Range.linear(0, 50)).lift
@@ -21,7 +21,7 @@ object PropertyTest extends Properties {
       _ <- assert(y < 87 && x <= 'r')
     } yield ()
 
-  def total: Property[Unit] =
+  def total: Property =
     for {
       x <- order(cheap).log("cheap")
       y <- order(expensive).log("expensive")

--- a/example/src/test/scala/hedgehog/example/ReverseTest.scala
+++ b/example/src/test/scala/hedgehog/example/ReverseTest.scala
@@ -9,7 +9,7 @@ object ReverseTest extends Properties {
       Prop("reverse", testReverse)
     )
 
-  def testReverse: Property[Unit] =
+  def testReverse: Property =
     for {
       xs <- Gen.alpha.list(Range.linear(0, 100)).forAll
       _ <- xs.reverse.reverse === xs

--- a/example/src/test/scala/hedgehog/example/ReverseTest.scala
+++ b/example/src/test/scala/hedgehog/example/ReverseTest.scala
@@ -12,6 +12,5 @@ object ReverseTest extends Properties {
   def testReverse: Property =
     for {
       xs <- Gen.alpha.list(Range.linear(0, 100)).forAll
-      _ <- xs.reverse.reverse === xs
-    } yield ()
+    } yield xs.reverse.reverse === xs
 }

--- a/runner/src/main/scala/hedgehog/runner/Properties.scala
+++ b/runner/src/main/scala/hedgehog/runner/Properties.scala
@@ -17,12 +17,12 @@ abstract class Properties {
   }
 }
 
-class Prop(val name: String, val result: Property[Unit])
+class Prop(val name: String, val result: Property)
 
 object Prop {
 
   /** Wrap the actual constructor so we can catch any exceptions thrown */
-  def apply(name: String, result: => Property[Unit]): Prop =
+  def apply(name: String, result: => Property): Prop =
     try {
       new Prop(name, result)
     } catch {

--- a/runner/src/main/scala/hedgehog/runner/Properties.scala
+++ b/runner/src/main/scala/hedgehog/runner/Properties.scala
@@ -17,7 +17,11 @@ abstract class Properties {
   }
 }
 
-class Prop(val name: String, val result: Property)
+class Prop(val name: String, val result: Property) {
+
+  def setProperty(r2: Property): Prop =
+    new Prop(name, r2)
+}
 
 object Prop {
 

--- a/runner/src/main/scala/hedgehog/runner/Properties.scala
+++ b/runner/src/main/scala/hedgehog/runner/Properties.scala
@@ -11,7 +11,7 @@ abstract class Properties {
   def main(args: Array[String]): Unit = {
     val seed = Seed.fromTime()
     tests.foreach(t => {
-      val report = t.result.check(seed).value
+      val report = Property.check(t.result, seed).value
       println(Prop.renderReport(this.getClass.getName, t, report, ansiCodesSupported = true))
     })
   }

--- a/sbt-test/src/main/scala/hedgehog/sbt/Framework.scala
+++ b/sbt-test/src/main/scala/hedgehog/sbt/Framework.scala
@@ -1,5 +1,6 @@
 package hedgehog.sbt
 
+import hedgehog._
 import hedgehog.core._
 import hedgehog.runner._
 import _root_.sbt.{testing => sbtt}
@@ -69,7 +70,7 @@ class Task(
         c.getDeclaredConstructor().newInstance()
     properties.tests.foreach(t => {
       val startTime = System.currentTimeMillis
-      val report = t.result.check(seed).value
+      val report = Property.check(t.result, seed).value
       val endTime = System.currentTimeMillis
       eventHandler.handle(Event.fromReport(taskDef, new sbtt.TestSelector(t.name), report, endTime - startTime))
 

--- a/test/src/test/scala/hedgehog/ErrorTest.scala
+++ b/test/src/test/scala/hedgehog/ErrorTest.scala
@@ -12,14 +12,14 @@ object ErrorTest extends Properties {
     , Prop("tests with generators that throw exception in flatMap will shrink", shrinkFlatMap)
     )
 
-  def noGen: Property[Unit] = {
+  def noGen: Property = {
     val e = new RuntimeException()
     val prop = Prop("", throw e)
     val r = prop.result.checkRandom.value
     getErrorLog(r.status) ==== List(Error(e))
   }
 
-  def shrinkMap: Property[Unit] = {
+  def shrinkMap: Property = {
     val e = new RuntimeException()
     val p = Gen.int(Range.linear(0, 100)).forAll.map(i =>
       if (i > 5) throw e else ()
@@ -28,7 +28,7 @@ object ErrorTest extends Properties {
     getErrorLog(r.status) ==== List(Info("6"), Error(e))
   }
 
-  def shrinkFlatMap: Property[Unit] = {
+  def shrinkFlatMap: Property = {
     val e = new RuntimeException()
     val p = Gen.int(Range.linear(0, 100)).forAll.flatMap(i =>
       if (i > 5) throw e else Property.success

--- a/test/src/test/scala/hedgehog/ErrorTest.scala
+++ b/test/src/test/scala/hedgehog/ErrorTest.scala
@@ -7,33 +7,33 @@ object ErrorTest extends Properties {
 
   def tests: List[Prop] =
     List(
-      Prop("tests with no generators don't throw exceptions", noGen)
-    , Prop("tests with generators that throw exception in map will shrink", shrinkMap)
-    , Prop("tests with generators that throw exception in flatMap will shrink", shrinkFlatMap)
+      Prop("tests with no generators don't throw exceptions", noGen.property)
+    , Prop("tests with generators that throw exception in map will shrink", shrinkMap.property)
+    , Prop("tests with generators that throw exception in flatMap will shrink", shrinkFlatMap.property)
     )
 
-  def noGen: Property = {
+  def noGen: Result = {
     val e = new RuntimeException()
     val prop = Prop("", throw e)
-    val r = prop.result.checkRandom.value
+    val r = Property.checkRandom(prop.result).value
     getErrorLog(r.status) ==== List(Error(e))
   }
 
-  def shrinkMap: Property = {
+  def shrinkMap: Result = {
     val e = new RuntimeException()
     val p = Gen.int(Range.linear(0, 100)).forAll.map(i =>
-      if (i > 5) throw e else ()
+      if (i > 5) throw e else Result.success
     )
-    val r = p.checkRandom.value
+    val r = Property.checkRandom(p).value
     getErrorLog(r.status) ==== List(Info("6"), Error(e))
   }
 
-  def shrinkFlatMap: Property = {
+  def shrinkFlatMap: Result = {
     val e = new RuntimeException()
     val p = Gen.int(Range.linear(0, 100)).forAll.flatMap(i =>
-      if (i > 5) throw e else Property.success
+      if (i > 5) throw e else Property.point(Result.success)
     )
-    val r = p.checkRandom.value
+    val r = Property.checkRandom(p).value
     getErrorLog(r.status) ==== List(Info("6"), Error(e))
   }
 

--- a/test/src/test/scala/hedgehog/GenTest.scala
+++ b/test/src/test/scala/hedgehog/GenTest.scala
@@ -13,14 +13,14 @@ object GenTest extends Properties {
     , Prop("fromSome none", testFromSomeNone)
     )
 
-  def testLong: Property[Unit] = {
+  def testLong: Property = {
     for {
       l <- Gen.long(Range.linear(Long.MaxValue / 2, Long.MaxValue)).forAll
       _ <- Property.assert(l >= Long.MaxValue / 2)
     } yield ()
   }
 
-  def testFrequency: Property[Unit] = {
+  def testFrequency: Property = {
     val g = Gen.frequency1((1, Gen.constant("a")), (1, Gen.constant("b")))
     val r1 = g.run(Size(1), Seed.fromLong(3)).run.value.value._2
     val r2 = g.run(Size(1), Seed.fromLong(1)).run.value.value._2
@@ -30,12 +30,12 @@ object GenTest extends Properties {
     } yield ()
   }
 
-  def testFromSomeSome: Property[Unit] = {
+  def testFromSomeSome: Property = {
     val r = Gen.fromSome(Gen.constant(()).option).forAll.checkRandom.value
     r ==== Report(SuccessCount(100), DiscardCount(0), OK)
   }
 
-  def testFromSomeNone: Property[Unit] = {
+  def testFromSomeNone: Property = {
     val r = Gen.fromSome(Gen.constant(Option.empty[Unit])).forAll.checkRandom.value
     r ==== Report(SuccessCount(0), DiscardCount(100), GaveUp)
   }

--- a/test/src/test/scala/hedgehog/PropertyTest.scala
+++ b/test/src/test/scala/hedgehog/PropertyTest.scala
@@ -13,7 +13,7 @@ object PropertyTest extends Properties {
     , Prop("total", total)
     )
 
-  def example1: Property[Unit] = {
+  def example1: Property = {
     val seed = Seed.fromLong(5489)
     val r = (for {
       x <- Gen.char('a', 'z').log("x")
@@ -59,7 +59,7 @@ object PropertyTest extends Properties {
   def order(gen: Gen[Item]): Gen[Order] =
     gen.list(Range.linear(0, 50)).map(Order)
 
-  def total: Property[Unit] = {
+  def total: Property = {
     val seed = Seed.fromLong(5489)
     val r = (for {
       x <- order(cheap).log("cheap")


### PR DESCRIPTION
/cc @Kevin-Lee @raronson @jystic @thumphries

There are two separate changes/commits in here.

The first is something I should have done earlier, and will break source compatibility, but better now than later.

The second unfortunately adds another subtle difference to the Haskell version. It introduces a strict "result" value from PropertyT. This is something I always felt like the Haskell version should have had. This change has been forced by some resource management issues, which is _more_ of an issue in a strict language. Haskell relies heavily on ResourceT which is something I'm not comfortable forcing on consumers of the Scala version, especially in light of a much simpler approach (as per this PR).
