### PR TITLE
Introduce PropertyR for testing properties with examples

### DIFF
--- a/core/src/main/scala/hedgehog/core/PropertyR.scala
+++ b/core/src/main/scala/hedgehog/core/PropertyR.scala
@@ -1,0 +1,24 @@
+package hedgehog.core
+
+import hedgehog.predef._
+
+/**
+ * A slightly different way to express a property, with the added benefit of exposing a pure "test".
+ * This enables running the test with specific examples, either as a "golden" test or from the shell. Or both.
+ * The trade-off is that the `A` needs to be exposed/declared, and it's likely to be some horrible multi-value tuple.
+ */
+class PropertyR[A](
+    val gen : PropertyT[Identity, A]
+  , val test: A => Result
+  ) {
+
+  def property: PropertyT[Identity, Result] =
+    gen.map(test)
+}
+
+object PropertyR {
+
+  /** Constructor function with split arguments to help type-inference */
+  def apply[A](gen: PropertyT[Identity, A])(test: A => Result): PropertyR[A] =
+    new PropertyR[A](gen, test)
+}

--- a/core/src/main/scala/hedgehog/package.scala
+++ b/core/src/main/scala/hedgehog/package.scala
@@ -1,7 +1,8 @@
 import hedgehog.core._
 import hedgehog.extra._
+import hedgehog.predef.ApplicativeSyntax
 
-package object hedgehog {
+package object hedgehog extends ApplicativeSyntax {
 
   type HM[A] = predef.Identity[A]
 
@@ -24,6 +25,9 @@ package object hedgehog {
 
   type Property = PropertyT[HM, Result]
   object Property extends PropertyTOps[HM]
+
+  type PropertyR[A] = core.PropertyR[A]
+  val PropertyR = core.PropertyR
 
   type Result = hedgehog.core.Result
   val Result = hedgehog.core.Result

--- a/core/src/main/scala/hedgehog/predef/ApplicativeSyntax.scala
+++ b/core/src/main/scala/hedgehog/predef/ApplicativeSyntax.scala
@@ -1,0 +1,33 @@
+package hedgehog.predef
+
+/**
+ * Convenience syntax for `Applicative` usage.
+ *
+ * Please forgive the use of overloading here, which avoids having to have an `ApplicativeBuilder`.
+ */
+trait ApplicativeSyntax {
+
+  def forTupled[M[_], A, B](ma: M[A], mb: M[B])(implicit F: Applicative[M]): M[(A, B)] =
+    F.ap(mb)(F.ap(ma)(F.point((a: A) => (b: B) => (a, b))))
+
+  def forTupled[M[_], A, B, C](ma: M[A], mb: M[B], mc: M[C])(implicit F: Applicative[M]): M[(A, B, C)] =
+    F.ap(mc)(F.ap(mb)(F.ap(ma)(F.point((a: A) => (b: B) => (c: C) => (a, b, c)))))
+
+  def forTupled[M[_], A, B, C, D](ma: M[A], mb: M[B], mc: M[C], md: M[D])(implicit F: Applicative[M]): M[(A, B, C, D)] =
+    F.ap(md)(F.ap(mc)(F.ap(mb)(F.ap(ma)(F.point((a: A) => (b: B) => (c: C) => (d: D) => (a, b, c, d))))))
+
+  def forTupled[M[_], A, B, C, D, E](ma: M[A], mb: M[B], mc: M[C], md: M[D], me: M[E])(implicit F: Applicative[M]): M[(A, B, C, D, E)] =
+    F.ap(me)(F.ap(md)(F.ap(mc)(F.ap(mb)(F.ap(ma)(F.point((a: A) => (b: B) => (c: C) => (d: D) => (e: E) => (a, b, c, d, e)))))))
+
+  def forTupled[M[_], A, B, C, D, E, F](ma: M[A], mb: M[B], mc: M[C], md: M[D], me: M[E], mf: M[F])(implicit F: Applicative[M]): M[(A, B, C, D, E, F)] =
+    F.ap(mf)(F.ap(me)(F.ap(md)(F.ap(mc)(F.ap(mb)(F.ap(ma)(F.point((a: A) => (b: B) => (c: C) => (d: D) => (e: E) => (f: F) => (a, b, c, d, e, f))))))))
+
+  def forTupled[M[_], A, B, C, D, E, F, G](ma: M[A], mb: M[B], mc: M[C], md: M[D], me: M[E], mf: M[F], mg: M[G])(implicit F: Applicative[M]): M[(A, B, C, D, E, F, G)] =
+    F.ap(mg)(F.ap(mf)(F.ap(me)(F.ap(md)(F.ap(mc)(F.ap(mb)(F.ap(ma)(F.point((a: A) => (b: B) => (c: C) => (d: D) => (e: E) => (f: F) => (g: G) => (a, b, c, d, e, f, g)))))))))
+
+  def forTupled[M[_], A, B, C, D, E, F, G, H](ma: M[A], mb: M[B], mc: M[C], md: M[D], me: M[E], mf: M[F], mg: M[G], mh: M[H])(implicit F: Applicative[M]): M[(A, B, C, D, E, F, G, H)] =
+    F.ap(mh)(F.ap(mg)(F.ap(mf)(F.ap(me)(F.ap(md)(F.ap(mc)(F.ap(mb)(F.ap(ma)(F.point((a: A) => (b: B) => (c: C) => (d: D) => (e: E) => (f: F) => (g: G) => (h: H) => (a, b, c, d, e, f, g, h))))))))))
+
+  def forTupled[M[_], A, B, C, D, E, F, G, H, I](ma: M[A], mb: M[B], mc: M[C], md: M[D], me: M[E], mf: M[F], mg: M[G], mh: M[H], mi: M[I])(implicit F: Applicative[M]): M[(A, B, C, D, E, F, G, H, I)] =
+    F.ap(mi)(F.ap(mh)(F.ap(mg)(F.ap(mf)(F.ap(me)(F.ap(md)(F.ap(mc)(F.ap(mb)(F.ap(ma)(F.point((a: A) => (b: B) => (c: C) => (d: D) => (e: E) => (f: F) => (g: G) => (h: H) => (i: I) => (a, b, c, d, e, f, g, h, i)))))))))))
+}

--- a/doc/haskell-differences.md
+++ b/doc/haskell-differences.md
@@ -3,6 +3,8 @@ Differences to Haskell Hedgehog
 
 This page documents where the Scala Hedgehog API deviates significantly from the Haskell version.
 
+- [Result](#result)
+  - [Property Plus Example](#property-plus-example)
 
 ## Result
 
@@ -59,4 +61,27 @@ def propUnixSort: Property =
       dir.delete()
     }
   }
+```
+
+
+### Property Plus Example
+
+The Scala version has an additional data type that allows generators to be applied to the final "test" in a way that
+can be invoked from by consumers.
+
+```
+def propReverse: PropertyR[List[Char]] =
+  PropertyR(
+    Gen.alpha.list(Range.linear(0, 100)).forAll
+  )(xs => xs.reverse.reverse === xs)
+```
+
+Here is an example of re-using the same method with both a property and a "golden" example test:
+
+```
+  def tests: List[Test] =
+    List(
+      property(propReverse)
+    , example(propReverse.test(List('a', 'b', 'c')))
+    )
 ```

--- a/example/src/test/scala/hedgehog/examples/PropertyRTest.scala
+++ b/example/src/test/scala/hedgehog/examples/PropertyRTest.scala
@@ -1,0 +1,33 @@
+package hedgehog.examples
+
+import hedgehog._
+import hedgehog.Gen._
+import hedgehog.runner._
+import hedgehog.examples.PropertyTest._
+
+object PropertyRTest extends Properties {
+
+  def tests: List[Test] =
+    List(
+      property("example1", example1.property)
+    , example("example1 example", example1.test(('x', 1)))
+    , property("total", total.property)
+    , example("total example", total.test((Order(Nil), Order(Nil))))
+    )
+
+  def example1: PropertyR[(Char, Int)] =
+    PropertyR(forTupled(
+      Gen.char('a', 'z').log("x")
+    , int(Range.linear(0, 50)).lift
+    )) {
+      case (x, y) => Result.assert(y < 87 && x <= 'r')
+    }
+
+  def total: PropertyR[(Order, Order)] =
+    PropertyR(forTupled(
+      order(cheap).log("cheap")
+    , order(expensive).log("expensive")
+    )) {
+      case (x, y) => merge(x, y).total.value === x.total.value + y.total.value
+    }
+}

--- a/example/src/test/scala/hedgehog/examples/PropertyTest.scala
+++ b/example/src/test/scala/hedgehog/examples/PropertyTest.scala
@@ -1,4 +1,4 @@
-package hedgehog.example
+package hedgehog.examples
 
 import hedgehog._
 import hedgehog.Gen._

--- a/example/src/test/scala/hedgehog/examples/ReverseTest.scala
+++ b/example/src/test/scala/hedgehog/examples/ReverseTest.scala
@@ -1,4 +1,5 @@
-package hedgehog.example
+package hedgehog.examples
+
 import hedgehog._
 import hedgehog.runner._
 


### PR DESCRIPTION
/cc @Kevin-Lee @raronson @thumphries @jystic 

This is something I've been thinking about. I kinda missed the old `QuickCheck` style when using `Arbitrary` arguments you would have top-level functions you could still test directly from the repl.

I'm not even sure I would use this myself, but it feels fairly easy to support both styles. 

What do people think? Is this solving a real problem? Or just dead code?

As an aside it's interesting that this looks basically the same as the Java [QuickTheories](https://github.com/ncredinburgh/QuickTheories/blob/master/core/src/main/java/org/quicktheories/impl/Property.java).

