### PR TITLE
 Switch to 1-based offset for size to simply inc

### DIFF
--- a/core/src/main/scala/hedgehog/Property.scala
+++ b/core/src/main/scala/hedgehog/Property.scala
@@ -33,7 +33,7 @@ trait PropertyTOps[M[_]] extends PropertyTReporting[M] {
     writeLog(Error(e)).flatMap(_ => failureA[A])
 
   def check(config: PropertyConfig, p: PropertyT[M, Result], seed: Seed)(implicit F: Monad[M]): M[Report] =
-    propertyT.report(config, Size(0), seed, p)
+    propertyT.report(config, None, seed, p)
 
   def checkRandom(config: PropertyConfig, p: PropertyT[M, Result])(implicit F: Monad[M]): M[Report] =
     // FIX: predef MonadIO

--- a/core/src/main/scala/hedgehog/Range.scala
+++ b/core/src/main/scala/hedgehog/Range.scala
@@ -18,6 +18,12 @@ case class Size(value: Int) {
     Size((value * 0.61803398875).toInt)
 }
 
+object Size {
+
+  def max: Int =
+    99
+}
+
 /**
  * A range describes the bounds of a number to generate, which may or may not
  * be dependent on a 'Size'.
@@ -213,11 +219,11 @@ object Range {
 
   /** Scale an integral linearly with the size parameter. */
   def scaleLinear[A](sz: Size, z: A, n: A)(implicit I: Integral[A], J: IntegralPlus[A]): A =
-    I.plus(z, J.times(I.minus(n, z), sz.value.toDouble / 99))
+    I.plus(z, J.times(I.minus(n, z), sz.value.toDouble / Size.max))
 
   /** Scale a fractional number linearly with the size parameter. */
   def scaleLinearFrac[A](sz: Size, z: A, n: A)(implicit F: Fractional[A]): A =
-    F.plus(z, F.times(F.minus(n, z), F.div(F.fromInt(sz.value), F.fromInt(99))))
+    F.plus(z, F.times(F.minus(n, z), F.div(F.fromInt(sz.value), F.fromInt(Size.max))))
 
   /** Check that list contains at least a certain number of elements. */
   def atLeast[A](n: Int, l: List[A]): Boolean =

--- a/core/src/main/scala/hedgehog/Range.scala
+++ b/core/src/main/scala/hedgehog/Range.scala
@@ -8,8 +8,8 @@ import hedgehog.predef.{DecimalPlus, IntegralPlus}
  */
 case class Size(value: Int) {
 
-  def incBy(v: Int): Size =
-    Size(value + v)
+  def incBy(v: Size): Size =
+    Size(value + v.value)
 
   /**
    * Scale a size using the golden ratio.
@@ -21,7 +21,7 @@ case class Size(value: Int) {
 object Size {
 
   def max: Int =
-    99
+    100
 }
 
 /**

--- a/core/src/main/scala/hedgehog/Range.scala
+++ b/core/src/main/scala/hedgehog/Range.scala
@@ -1,5 +1,6 @@
 package hedgehog
 
+import hedgehog.core.NumericPlus
 import hedgehog.predef.{DecimalPlus, IntegralPlus}
 
 /**
@@ -7,6 +8,10 @@ import hedgehog.predef.{DecimalPlus, IntegralPlus}
  * meaning of which depends on the particular generator used.
  */
 case class Size(value: Int) {
+
+  /** Represents the size as a percentage (0 - 1) which is useful for range calculations */
+  def percentage: Double =
+    value.toDouble / Size.max
 
   def incBy(v: Size): Size =
     Size(value + v.value)
@@ -136,7 +141,7 @@ object Range {
    * (0,10)
    * }}}
    */
-  def linear[A : Integral : IntegralPlus](x: A, y: A): Range[A] =
+  def linear[A : Integral : IntegralPlus : NumericPlus](x: A, y: A): Range[A] =
     linearFrom(x, x, y)
 
   /**
@@ -154,7 +159,7 @@ object Range {
    * (-10,20)
    * }}}
    */
-  def linearFrom[A](z: A, x: A, y: A)(implicit I: Integral[A], J: IntegralPlus[A]): Range[A] =
+  def linearFrom[A](z: A, x: A, y: A)(implicit I: Integral[A], J: IntegralPlus[A], R: NumericPlus[A]): Range[A] =
     // Check for overflow and if we do then start using BigInt
     if (I.lt(I.minus(y, x), I.zero) && I.gt(y, I.zero)) {
       linearFrom_(J.toBigInt(z), J.toBigInt(x), J.toBigInt(y))
@@ -163,7 +168,7 @@ object Range {
       linearFrom_(z, x, y)
     }
 
-  def linearFrom_[A : Integral : IntegralPlus](z: A, x: A, y: A): Range[A] =
+  def linearFrom_[A : Integral : NumericPlus](z: A, x: A, y: A): Range[A] =
     Range(z, sz => (
         clamp(x, y, scaleLinear(sz, z, x))
       , clamp(x, y, scaleLinear(sz, z, y))
@@ -176,7 +181,7 @@ object Range {
    *
    * This works the same as 'linear', but for fractional values.
    */
-  def linearFrac[A : Fractional : DecimalPlus](x: A, y: A): Range[A] =
+  def linearFrac[A : Fractional : DecimalPlus : NumericPlus](x: A, y: A): Range[A] =
     linearFracFrom(x, x, y)
 
   /**
@@ -184,7 +189,7 @@ object Range {
    *
    * This works the same as [[linearFrom]], but for fractional values.
    */
-  def linearFracFrom[A](z: A, x: A, y: A)(implicit I: Fractional[A], J: DecimalPlus[A]): Range[A] =
+  def linearFracFrom[A](z: A, x: A, y: A)(implicit I: Fractional[A], J: DecimalPlus[A], R: NumericPlus[A]): Range[A] =
     // Check for gross imprecision and lift to `BigDecimal` to ensure we don't produce a bad range
     if (I.toDouble(I.minus(y, x)).isInfinity) {
       linearFracFrom_(J.toBigDecimal(z), J.toBigDecimal(x), J.toBigDecimal(y))
@@ -193,7 +198,7 @@ object Range {
       linearFracFrom_(z, x, y)
     }
 
-  def linearFracFrom_[A : Fractional](z: A, x: A, y: A): Range[A] =
+  def linearFracFrom_[A : Fractional : NumericPlus](z: A, x: A, y: A): Range[A] =
     Range(z, sz => (
         clamp(x, y, scaleLinearFrac(sz, z, x))
       , clamp(x, y, scaleLinearFrac(sz, z, y))
@@ -218,12 +223,12 @@ object Range {
       O.min(y, O.max(x, n))
 
   /** Scale an integral linearly with the size parameter. */
-  def scaleLinear[A](sz: Size, z: A, n: A)(implicit I: Integral[A], J: IntegralPlus[A]): A =
-    I.plus(z, J.times(I.minus(n, z), sz.value.toDouble / Size.max))
+  def scaleLinear[A](sz: Size, z: A, n: A)(implicit I: Integral[A], J: NumericPlus[A]): A =
+    I.plus(z, J.timesDouble(I.minus(n, z), sz.percentage))
 
   /** Scale a fractional number linearly with the size parameter. */
-  def scaleLinearFrac[A](sz: Size, z: A, n: A)(implicit F: Fractional[A]): A =
-    F.plus(z, F.times(F.minus(n, z), F.div(F.fromInt(sz.value), F.fromInt(Size.max))))
+  def scaleLinearFrac[A](sz: Size, z: A, n: A)(implicit F: Fractional[A], J: NumericPlus[A]): A =
+    F.plus(z, J.timesDouble(F.minus(n, z), sz.percentage))
 
   /** Check that list contains at least a certain number of elements. */
   def atLeast[A](n: Int, l: List[A]): Boolean =

--- a/core/src/main/scala/hedgehog/core/NumericPlus.scala
+++ b/core/src/main/scala/hedgehog/core/NumericPlus.scala
@@ -1,0 +1,65 @@
+package hedgehog.core
+
+trait NumericPlus[A] {
+
+  def timesDouble(a: A, b: Double): A
+}
+
+object NumericPlus {
+
+  implicit def ByteRatio: NumericPlus[Byte] =
+    new NumericPlus[Byte] {
+
+      override def timesDouble(a: Byte, b: Double): Byte =
+        (a.toDouble * b).toByte
+    }
+
+  implicit def ShortRatio: NumericPlus[Short] =
+    new NumericPlus[Short] {
+
+      override def timesDouble(a: Short, b: Double): Short =
+        (a.toDouble * b).toShort
+    }
+
+  implicit def IntRatio: NumericPlus[Int] =
+    new NumericPlus[Int] {
+
+      override def timesDouble(a: Int, b: Double): Int =
+        (a.toDouble * b).toInt
+      }
+
+  implicit def LongRatio: NumericPlus[Long] =
+    new NumericPlus[Long] {
+
+      override def timesDouble(a: Long, b: Double): Long =
+        (a.toDouble * b).toLong
+    }
+
+  implicit def BigIntRatio: NumericPlus[BigInt] =
+    new NumericPlus[BigInt] {
+
+      override def timesDouble(a: BigInt, b: Double): BigInt =
+        (BigDecimal(a) * b).toBigInt
+    }
+
+  implicit def FloatRatio: NumericPlus[Float] =
+    new NumericPlus[Float] {
+
+      override def timesDouble(a: Float, b: Double): Float =
+        (a.toDouble * b).toFloat
+    }
+
+  implicit def DoubleRatio: NumericPlus[Double] =
+    new NumericPlus[Double] {
+
+      override def timesDouble(a: Double, b: Double): Double =
+        a * b
+    }
+
+  implicit def BigDecimalRatio: NumericPlus[BigDecimal] =
+    new NumericPlus[BigDecimal] {
+
+      override def timesDouble(a: BigDecimal, b: Double): BigDecimal =
+        a * b
+    }
+}

--- a/core/src/main/scala/hedgehog/core/PropertyT.scala
+++ b/core/src/main/scala/hedgehog/core/PropertyT.scala
@@ -114,12 +114,14 @@ trait PropertyTReporting[M[_]] {
         }
     }
 
-  def report(config: PropertyConfig, size0: Size, seed0: Seed, p: PropertyT[M, Result])(implicit F: Monad[M]): M[Report] = {
+  def report(config: PropertyConfig, size0: Option[Size], seed0: Seed, p: PropertyT[M, Result])(implicit F: Monad[M]): M[Report] = {
     // Increase the size proportionally to the number of tests to ensure better coverage of the desired range
-    val sizeInc = Math.max(1, 100 / config.testLimit.value)
+    val sizeInc = Size(Math.max(1, Size.max / config.testLimit.value))
+    // Start the size at whatever remainder we have to ensure we run with "max" at least once
+    val sizeInit = Size(Size.max % Math.min(config.testLimit.value, Size.max)).incBy(sizeInc)
     def loop(successes: SuccessCount, discards: DiscardCount, size: Size, seed: Seed): M[Report] =
       if (size.value > Size.max)
-        loop(successes, discards, Size(0), seed)
+        loop(successes, discards, sizeInit, seed)
       else if (successes.value >= config.testLimit.value)
         F.point(Report(successes, discards, OK))
       else if (discards.value >= config.discardLimit.value)
@@ -140,11 +142,11 @@ trait PropertyTReporting[M[_]] {
                 loop(successes.inc, discards, size.incBy(sizeInc), x.value._1)
           }
         )
-    loop(SuccessCount(0), DiscardCount(0), size0, seed0)
+    loop(SuccessCount(0), DiscardCount(0), size0.getOrElse(sizeInit), seed0)
   }
 
   def recheck(config: PropertyConfig, size: Size, seed: Seed)(p: PropertyT[M, Result])(implicit F: Monad[M]): M[Report] =
-    report(config.copy(testLimit = SuccessCount(1)), size, seed, p)
+    report(config.copy(testLimit = SuccessCount(1)), Some(size), seed, p)
 }
 
 /**********************************************************************/

--- a/core/src/main/scala/hedgehog/core/PropertyT.scala
+++ b/core/src/main/scala/hedgehog/core/PropertyT.scala
@@ -144,7 +144,7 @@ trait PropertyTReporting[M[_]] {
   }
 
   def recheck(config: PropertyConfig, size: Size, seed: Seed)(p: PropertyT[M, Result])(implicit F: Monad[M]): M[Report] =
-    report(config.copy(testLimit = SuccessCount(1)), Size(0), seed, p)
+    report(config.copy(testLimit = SuccessCount(1)), size, seed, p)
 }
 
 /**********************************************************************/

--- a/core/src/main/scala/hedgehog/core/PropertyT.scala
+++ b/core/src/main/scala/hedgehog/core/PropertyT.scala
@@ -118,7 +118,7 @@ trait PropertyTReporting[M[_]] {
     // Increase the size proportionally to the number of tests to ensure better coverage of the desired range
     val sizeInc = Math.max(1, 100 / config.testLimit.value)
     def loop(successes: SuccessCount, discards: DiscardCount, size: Size, seed: Seed): M[Report] =
-      if (size.value > 99)
+      if (size.value > Size.max)
         loop(successes, discards, Size(0), seed)
       else if (successes.value >= config.testLimit.value)
         F.point(Report(successes, discards, OK))

--- a/core/src/main/scala/hedgehog/predef/IntegralPlus.scala
+++ b/core/src/main/scala/hedgehog/predef/IntegralPlus.scala
@@ -3,8 +3,6 @@ package hedgehog.predef
 /** Operations that are unfortunately missing from `Integral` */
 trait IntegralPlus[A] {
 
-  def times(a: A, b: Double): A
-
   def toBigInt(a: A): BigInt
 
   def fromBigInt(a: BigInt): A
@@ -14,9 +12,6 @@ object IntegralPlus {
 
   implicit def ByteIntegralPlus: IntegralPlus[Byte] =
     new IntegralPlus[Byte] {
-
-      override def times(a: Byte, b: Double): Byte =
-        (a.toDouble * b).toByte
 
       override def toBigInt(a: Byte): BigInt =
         BigInt(a)
@@ -28,9 +23,6 @@ object IntegralPlus {
   implicit def ShortIntegralPlus: IntegralPlus[Short] =
     new IntegralPlus[Short] {
 
-      override def times(a: Short, b: Double): Short =
-        (a.toDouble * b).toShort
-
       override def toBigInt(a: Short): BigInt =
         BigInt(a)
 
@@ -40,9 +32,6 @@ object IntegralPlus {
 
   implicit def IntIntegralPlus: IntegralPlus[Int] =
     new IntegralPlus[Int] {
-
-      override def times(a: Int, b: Double): Int =
-        (a.toDouble * b).toInt
 
       override def toBigInt(a: Int): BigInt =
         BigInt(a)
@@ -54,27 +43,10 @@ object IntegralPlus {
   implicit def LongIntegralPlus: IntegralPlus[Long] =
     new IntegralPlus[Long] {
 
-      override def times(a: Long, b: Double): Long =
-        (a.toDouble * b).toLong
-
       override def toBigInt(a: Long): BigInt =
         BigInt(a)
 
       override def fromBigInt(a: BigInt): Long =
         a.toLong
-    }
-
-
-  implicit def BigIntIntegralPlus: IntegralPlus[BigInt] =
-    new IntegralPlus[BigInt] {
-
-      override def times(a: BigInt, b: Double): BigInt =
-        (BigDecimal(a) * b).toBigInt
-
-      override def toBigInt(a: BigInt): BigInt =
-        a
-
-      override def fromBigInt(a: BigInt): BigInt =
-        a
     }
 }

--- a/test/src/test/scala/hedgehog/PropertyTest.scala
+++ b/test/src/test/scala/hedgehog/PropertyTest.scala
@@ -20,10 +20,10 @@ object PropertyTest extends Properties {
       y <- int(Range.linear(0, 50)).log("y")
       _ <- if (y % 2 == 0) Property.discard else Property.point(())
     } yield Result.assert(y < 87 && x <= 'r'), seed).value
-    Result.assert(r == Report(SuccessCount(0), DiscardCount(2), Failed(ShrinkCount(1), List(
+    r ==== Report(SuccessCount(2), DiscardCount(4), Failed(ShrinkCount(2), List(
         ForAll("x", "s")
       , ForAll("y", "1"))
-      )))
+      ))
   }
 
   case class USD(value: Long)
@@ -65,10 +65,10 @@ object PropertyTest extends Properties {
       y <- order(expensive).log("expensive")
     } yield Result.assert(merge(x, y).total.value == x.total.value + y.total.value)
       , seed).value
-    Result.assert(r == Report(SuccessCount(3), DiscardCount(0), Failed(ShrinkCount(5), List(
+    r ==== Report(SuccessCount(1), DiscardCount(0), Failed(ShrinkCount(4), List(
         ForAll("cheap", "Order(List())")
       , ForAll("expensive", "Order(List(Item(oculus,USD(1000))))"
-      )))))
+      ))))
   }
 
   def fail: Result =

--- a/test/src/test/scala/hedgehog/RangeTest.scala
+++ b/test/src/test/scala/hedgehog/RangeTest.scala
@@ -14,15 +14,15 @@ object RangeTest extends Properties {
     val r1 = Range.linear(Int.MinValue, Int.MaxValue)
     val r2 = Range.linear(-1, Int.MaxValue)
     Result.all(List(
-      r1.bounds(Size(1))._2 ==== -2104100140
-    , r1.bounds(Size(25))._2 ==== -1062895948
-    , r1.bounds(Size(75))._2 ==== 1106279454
-    , r1.bounds(Size(99))._2 ==== 2147483647
+      r1.bounds(Size(1))._2 ==== -2104533976
+    , r1.bounds(Size(25))._2 ==== -1073741825
+    , r1.bounds(Size(75))._2 ==== 1073741823
+    , r1.bounds(Size(99))._2 ==== 2104533974
     , r1.bounds(Size(100))._2 ==== 2147483647
-    , r2.bounds(Size(1))._2 ==== 21691753
-    , r2.bounds(Size(25))._2 ==== 542293849
-    , r2.bounds(Size(75))._2 ==== 1626881550
-    , r2.bounds(Size(99))._2 ==== 2147483647
+    , r2.bounds(Size(1))._2 ==== 21474835
+    , r2.bounds(Size(25))._2 ==== 536870911
+    , r2.bounds(Size(75))._2 ==== 1610612735
+    , r2.bounds(Size(99))._2 ==== 2126008810
     , r2.bounds(Size(100))._2 ==== 2147483647
     ))
   }
@@ -30,10 +30,10 @@ object RangeTest extends Properties {
   def testFractional: Result = {
     val r1 = Range.linearFrac(Double.MinValue, Double.MaxValue)
     Result.all(List(
-      r1.bounds(Size(1))._2 ==== -1.7613761018347941E308
-    , r1.bounds(Size(25))._2 ==== -8.897673091742775E307
-    , r1.bounds(Size(75))._2 ==== 9.26084342201799E307
-    , r1.bounds(Size(99))._2 ==== 1.7976931348623157E308
+      r1.bounds(Size(1))._2 ==== -1.7617392721650694E308
+    , r1.bounds(Size(25))._2 ==== -8.988465674311579E307
+    , r1.bounds(Size(75))._2 ==== 8.988465674311579E307
+    , r1.bounds(Size(99))._2 ==== 1.7617392721650694E308
     , r1.bounds(Size(100))._2 ==== 1.7976931348623157E308
     ))
   }


### PR DESCRIPTION
/cc @Kevin-Lee @moodmosaic @thumphries @jystic 

This is probably more controversial than the previous PR (https://github.com/hedgehogqa/scala-hedgehog/pull/55). This ensures that we always hit the max size instead of something approaching it. For example running 3 tests previously would run with size `0, 33, 66` instead of `34, 67, 100` as it would now.

I'm definitely interested to see if people think this is a good idea. 