### PR TITLE
Remove === and update docs accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ object PropertyTest extends Properties {
   def testReverse: Property =
     for {
       xs <- Gen.alpha.list(Range.linear(0, 100)).forAll
-    } yield xs.reverse.reverse === xs
+    } yield xs.reverse.reverse ==== xs
 }
 ```
 

--- a/core/src/main/scala/hedgehog/package.scala
+++ b/core/src/main/scala/hedgehog/package.scala
@@ -38,7 +38,7 @@ package object hedgehog extends ApplicativeSyntax {
   implicit class Syntax[A](a1: A) {
 
      // FIX Is there a way to get this to work with PropertyT and type-inference?
-     def ===(a2: A): Result = {
+     def ====(a2: A): Result = {
        if (a1 == a2)
          Result.success
        else
@@ -48,8 +48,5 @@ package object hedgehog extends ApplicativeSyntax {
            .log(a2.toString)
      }
 
-    // To avoid name clashes
-    def ====(a2: A): Result =
-      ===(a2)
   }
 }

--- a/doc/haskell-differences.md
+++ b/doc/haskell-differences.md
@@ -16,7 +16,7 @@ prop_reverse :: Property
 prop_reverse =
   property $ do
     xs <- forAll $ Gen.list (Range.linear 0 100) Gen.alpha
-    reverse (reverse xs) === xs
+    reverse (reverse xs) ==== xs
 ```
 
 And the corresponding Scala version:
@@ -25,7 +25,7 @@ And the corresponding Scala version:
 def propReverse: Property =
   for {
     xs <- Gen.alpha.list(Range.linear(0, 100)).forAll
-  } yield xs.reverse.reverse === xs
+  } yield xs.reverse.reverse ==== xs
 ```
 
 ### Resource Management
@@ -42,7 +42,7 @@ prop_unix_sort =
     test . runResourceT $ do
       dir <- Temp.createTempDirectory Nothing "prop_dir"
       ...
-      values0 === values
+      values0 ==== values
 ```
 
 To simplify this, and to reduce surprises, the final result in the Scala version is now a separate
@@ -56,7 +56,7 @@ def propUnixSort: Property =
   } yield {
     val dir = java.io.Files.createTempDirectory(getClass.getSimpleName).toFile
     try {
-      values0 === values
+      values0 ==== values
     } finally {
       dir.delete()
     }
@@ -73,7 +73,7 @@ can be invoked from by consumers.
 def propReverse: PropertyR[List[Char]] =
   PropertyR(
     Gen.alpha.list(Range.linear(0, 100)).forAll
-  )(xs => xs.reverse.reverse === xs)
+  )(xs => xs.reverse.reverse ==== xs)
 ```
 
 Here is an example of re-using the same method with both a property and a "golden" example test:

--- a/doc/migration-scalacheck.md
+++ b/doc/migration-scalacheck.md
@@ -26,7 +26,7 @@ Some basic rules:
    comprehension.
 - Return your `Prop` or `Boolean` assetions with `Result.assert(...)`
 - Replace [label] or `:|` with  [Result.log(...)][log]
-- Replace equality assertions like `?=` with `===`
+- Replace equality assertions like `?=` with `====`
 
 
 ### ScalaCheck

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -58,7 +58,7 @@ object Spec extends Properties {
     for {
        l1 <- Gen.int(Range.linear(-100, 100)).list(Range.linear(0, 100)).forAll
        l2 <- Gen.int(Range.linear(-100, 100)).list(Range.linear(0, 100)).forAll
-     } yield l1.size + l2.size === (l1 ::: l2).size
+     } yield l1.size + l2.size ==== (l1 ::: l2).size
 }
 ```
 
@@ -77,7 +77,7 @@ OK, that seemed alright. Now define another property.
 def propSqrt: Property =
   for {
     n <- Gen.int(Range.linearFrom(0, -100, 100)).forAll
-  } yield scala.math.sqrt(n * n) === n
+  } yield scala.math.sqrt(n * n) ==== n
 ```
 
 Check it!
@@ -172,11 +172,11 @@ Spec$.add: Falsified after 1 passed tests
 
 That's it? What about a useful message telling us what failed?
 For starters, given that we're just doing an assertion Hedgehog comes with the
-convenient `===` operator:
+convenient `====` operator:
 
 ```scala
 def testAdd: Result =
-  1 + 2 === 3 + 4
+  1 + 2 ==== 3 + 4
 ```
 
 ```
@@ -265,8 +265,8 @@ def propMul: Property =
   } yield {
     val res = n*m
     Result.all(List(
-      (res / m === n).log("div1")
-    , (res / n === m).log("div2")
+      (res / m ==== n).log("div1")
+    , (res / n ==== m).log("div2")
     , Result.assert(res > m).log("lt1")
     , Result.assert(res > n).log("lt2")
     )).log("evidence = " + res)
@@ -297,10 +297,10 @@ boolean logic.
 
 ```scala
 def p1: Result =
-  "a" === "a"
+  "a" ==== "a"
 
 def p2: Result =
-  1 === 1
+  1 ==== 1
 
 def p3: Result =
   p1 and p2
@@ -466,7 +466,7 @@ val propMakeList: Property =
     n <- Gen.int(Range.linear(0, 100))
       .ensure(n => n % 2 == 0)
       .forAll
-  } yield List.fill(n)("").length === n
+  } yield List.fill(n)("").length ==== n
 }
 ```
 
@@ -483,7 +483,7 @@ def propTrivial: Property =
     n <- Gen.int(Range.linear(0, 100))
      .ensure(n => n == 0)
      .forAll
-  } yield n === 0
+  } yield n ==== 0
 ```
 
 ```
@@ -538,7 +538,7 @@ shrinking in action!
 def p1: Property =
   for {
     l <- Gen.int(Range.linearFrom(0, -100, 100)).list(Range.linear(0, 100)).log("l")
-  } yield l === l.distinct
+  } yield l ==== l.distinct
 ```
 
 Now, run the tests:
@@ -562,7 +562,7 @@ def p1: Property =
     l <- Gen.int(Range.linearFrom(0, -100, 100)).list(Range.linear(0, 100)).log("i")
   } yield {
     println(l)
-    l === l.distinct
+    l ==== l.distinct
   }
 ```
 

--- a/example/src/test/scala/hedgehog/examples/PropertyRTest.scala
+++ b/example/src/test/scala/hedgehog/examples/PropertyRTest.scala
@@ -28,6 +28,6 @@ object PropertyRTest extends Properties {
       order(cheap).log("cheap")
     , order(expensive).log("expensive")
     )) {
-      case (x, y) => merge(x, y).total.value === x.total.value + y.total.value
+      case (x, y) => merge(x, y).total.value ==== x.total.value + y.total.value
     }
 }

--- a/example/src/test/scala/hedgehog/examples/PropertyTest.scala
+++ b/example/src/test/scala/hedgehog/examples/PropertyTest.scala
@@ -23,7 +23,7 @@ object PropertyTest extends Properties {
     for {
       x <- order(cheap).log("cheap")
       y <- order(expensive).log("expensive")
-    } yield merge(x, y).total.value === x.total.value + y.total.value
+    } yield merge(x, y).total.value ==== x.total.value + y.total.value
 
   case class USD(value: Long)
   case class Item(name: String, price: USD)

--- a/example/src/test/scala/hedgehog/examples/ReverseTest.scala
+++ b/example/src/test/scala/hedgehog/examples/ReverseTest.scala
@@ -13,5 +13,5 @@ object ReverseTest extends Properties {
   def testReverse: Property =
     for {
       xs <- Gen.alpha.list(Range.linear(0, 100)).forAll
-    } yield xs.reverse.reverse === xs
+    } yield xs.reverse.reverse ==== xs
 }


### PR DESCRIPTION
This PR is to remove triple-equals (`===`) from Hedgehog.
Since `===` is such a common operator used by other well-known libraries such as Scalaz, Spark, etc., it can cause conflicts when using Hedgehog's `===` with those libraries.

I think, as Hedgehog has an alternative that is `====`, `===` can be and should be removed.