### PR TITLE
Fix the broken link found in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ NOTE: This requires the test to be an `object` and _not_ a `class`.
 
 ## Example
 
-See the [examples](example/src/test/scala/hedgehog/example/) module for working versions.
+See the [examples](example/src/test/scala/hedgehog/examples/) module for working versions.
 
 ```scala
 import hedgehog._


### PR DESCRIPTION
Fixed: the broken link found in the README.md
I wrote some Scala script to check if there's any broken link in every md file scala-hedgehog has and that's the only broken one I found.