### PR TITLE
Topic/issue 62 memory lazy tree children

### DIFF
--- a/core/src/main/scala/hedgehog/core/PropertyT.scala
+++ b/core/src/main/scala/hedgehog/core/PropertyT.scala
@@ -83,7 +83,7 @@ object PropertyT {
 
 trait PropertyTReporting[M[_]] {
 
-  def takeSmallest(n: ShrinkCount, slimit: ShrinkLimit, t: Node[M, Option[(List[Log], Option[Result])]])(implicit F: Monad[M]): M[Status] =
+  def takeSmallest(n: ShrinkCount, slimit: ShrinkLimit, t: Tree[M, Option[(List[Log], Option[Result])]])(implicit F: Monad[M]): M[Status] =
     t.value match {
       case None =>
         F.point(Status.gaveUp)
@@ -95,12 +95,12 @@ trait PropertyTReporting[M[_]] {
           } else {
             F.map(F.bind(t.children)(x =>
               findMapM(x)(m =>
-                m.run.value match {
+                m.value match {
                   case Some((_, None)) =>
-                    F.map(takeSmallest(n.inc, slimit, m.run))(some)
+                    F.map(takeSmallest(n.inc, slimit, m))(some)
                   case Some((_, Some(r2))) =>
                     if (!r2.success)
-                      F.map(takeSmallest(n.inc, slimit, m.run))(some)
+                      F.map(takeSmallest(n.inc, slimit, m))(some)
                     else
                       F.point(Option.empty[Status])
                   case None =>
@@ -127,7 +127,7 @@ trait PropertyTReporting[M[_]] {
       else if (discards.value >= config.discardLimit.value)
         F.point(Report(successes, discards, GaveUp))
       else {
-        val x = p.run.run(size, seed).run
+        val x = p.run.run(size, seed)
         x.value._2 match {
           case None =>
             loop(successes, discards.inc, size.incBy(sizeInc), x.value._1)

--- a/core/src/main/scala/hedgehog/core/Tree.scala
+++ b/core/src/main/scala/hedgehog/core/Tree.scala
@@ -2,40 +2,25 @@ package hedgehog.core
 
 import hedgehog.predef._
 
-case class Node[M[_], A](value: A, children: M[List[Tree[M, A]]]) {
-
-  def map[B](f: A => B)(implicit F: Functor[M]): Node[M, B] =
-    Node.NodeFunctor.map(this)(f)
-}
-
 /**
  * NOTE: This differs from the Haskell version by not having an effect on the `Node` for performance reasons.
  * See `haskell-difference.md` for more information.
  */
-case class Tree[M[_], A](run: Node[M, A]) {
+case class Tree[M[_], A](value: A, children: M[List[Tree[M, A]]]) {
 
   def map[B](f: A => B)(implicit F: Functor[M]): Tree[M, B] =
-    Tree(Node.NodeFunctor[M].map(run)(f))
+    Tree.TreeFunctor[M].map(this)(f)
 
   def flatMap[B](f: A => Tree[M, B])(implicit F: Monad[M]): Tree[M, B] =
     Tree.TreeMonad[M].bind(this)(f)
 
   def expand(f: A => List[A])(implicit F: Applicative[M]): Tree[M, A] =
     Tree(
-      Node(run.value, F.map(run.children)(_.map(_.expand(f)) ++ Tree.unfoldForest(identity[A], f, run.value)(F)))
+      this.value, F.map(this.children)(_.map(_.expand(f)) ++ Tree.unfoldForest(identity[A], f, this.value)(F))
     )
 
   def prune(implicit F: Applicative[M]): Tree[M, A] =
-    Tree(Node(run.value, F.point(List())))
-}
-
-object Node {
-
-  implicit def NodeFunctor[M[_]](implicit F: Functor[M]): Functor[Node[M, ?]] =
-    new Functor[Node[M, ?]] {
-      override def map[A, B](fa: Node[M, A])(f: A => B): Node[M, B] =
-        Node(f(fa.value), F.map(fa.children)(_.map(_.map(f))))
-    }
+    Tree(this.value, F.point(List()))
 }
 
 abstract class TreeImplicits1 {
@@ -43,7 +28,7 @@ abstract class TreeImplicits1 {
   implicit def TreeFunctor[M[_]](implicit F: Functor[M]): Functor[Tree[M, ?]] =
     new Functor[Tree[M, ?]] {
       override def map[A, B](fa: Tree[M, A])(f: A => B): Tree[M, B] =
-        fa.map(f)
+        Tree(f(fa.value), F.map(fa.children)(_.map(_.map(f))))
     }
 }
 
@@ -52,7 +37,7 @@ abstract class TreeImplicits2 extends TreeImplicits1 {
   implicit def TreeApplicative[M[_]](implicit F: Monad[M]): Applicative[Tree[M, ?]] =
     new Applicative[Tree[M, ?]] {
       def point[A](a: => A): Tree[M, A] =
-        Tree(Node(a, F.point(List())))
+        Tree(a, F.point(List()))
       def ap[A, B](fa: => Tree[M, A])(f: => Tree[M, A => B]): Tree[M, B] =
         // FIX This isn't ideal, but if it's good enough for the Haskell implementation it's good enough for us
         // https://github.com/hedgehogqa/haskell-hedgehog/pull/173
@@ -72,15 +57,15 @@ object Tree extends TreeImplicits2 {
       override def point[A](a: => A): Tree[M, A] =
         TreeApplicative(F).point(a)
       override def bind[A, B](fa: Tree[M, A])(f: A => Tree[M, B]): Tree[M, B] = {
-        val y = f(fa.run.value).run
+        val y = f(fa.value)
         Tree(
-          Node(y.value, F.bind(fa.run.children)(x => F.map(y.children)(ys => x.map(_.flatMap(f)) ++ ys)))
+          y.value, F.bind(fa.children)(x => F.map(y.children)(ys => x.map(_.flatMap(f)) ++ ys))
         )
       }
     }
 
   def unfoldTree[M[_], A, B](f: B => A, g: B => List[B], x: B)(implicit F: Applicative[M]): Tree[M, A] =
-    Tree(Node(f(x), F.point(unfoldForest(f, g, x))))
+    Tree(f(x), F.point(unfoldForest(f, g, x)))
 
   def unfoldForest[M[_], A, B](f: B => A, g: B => List[B], x: B)(implicit F: Applicative[M]): List[Tree[M, A]] =
     g(x).map(y => unfoldTree(f, g, y)(F))

--- a/core/src/main/scala/hedgehog/core/Tree.scala
+++ b/core/src/main/scala/hedgehog/core/Tree.scala
@@ -2,27 +2,31 @@ package hedgehog.core
 
 import hedgehog.predef._
 
-case class Node[M[_], A](value: A, children: List[Tree[M, A]]) {
+case class Node[M[_], A](value: A, children: M[List[Tree[M, A]]]) {
 
   def map[B](f: A => B)(implicit F: Functor[M]): Node[M, B] =
     Node.NodeFunctor.map(this)(f)
 }
 
-case class Tree[M[_], A](run: M[Node[M, A]]) {
+/**
+ * NOTE: This differs from the Haskell version by not having an effect on the `Node` for performance reasons.
+ * See `haskell-difference.md` for more information.
+ */
+case class Tree[M[_], A](run: Node[M, A]) {
 
   def map[B](f: A => B)(implicit F: Functor[M]): Tree[M, B] =
-    Tree(F.map(run)(n => Node.NodeFunctor[M].map(n)(f)))
+    Tree(Node.NodeFunctor[M].map(run)(f))
 
   def flatMap[B](f: A => Tree[M, B])(implicit F: Monad[M]): Tree[M, B] =
     Tree.TreeMonad[M].bind(this)(f)
 
-  def expand(f: A => List[A])(implicit F: Monad[M]): Tree[M, A] =
-    Tree(F.bind(run)(x =>
-      F.point(Node(x.value, x.children.map(_.expand(f)) ++ Tree.unfoldForest(identity[A], f, x.value)(F)))
-    ))
+  def expand(f: A => List[A])(implicit F: Applicative[M]): Tree[M, A] =
+    Tree(
+      Node(run.value, F.map(run.children)(_.map(_.expand(f)) ++ Tree.unfoldForest(identity[A], f, run.value)(F)))
+    )
 
-  def prune(implicit F: Monad[M]): Tree[M, A] =
-    Tree(F.bind(run)(x => F.point(Node(x.value, List()))))
+  def prune(implicit F: Applicative[M]): Tree[M, A] =
+    Tree(Node(run.value, F.point(List())))
 }
 
 object Node {
@@ -30,7 +34,7 @@ object Node {
   implicit def NodeFunctor[M[_]](implicit F: Functor[M]): Functor[Node[M, ?]] =
     new Functor[Node[M, ?]] {
       override def map[A, B](fa: Node[M, A])(f: A => B): Node[M, B] =
-        Node(f(fa.value), fa.children.map(_.map(f)))
+        Node(f(fa.value), F.map(fa.children)(_.map(_.map(f))))
     }
 }
 
@@ -48,7 +52,7 @@ abstract class TreeImplicits2 extends TreeImplicits1 {
   implicit def TreeApplicative[M[_]](implicit F: Monad[M]): Applicative[Tree[M, ?]] =
     new Applicative[Tree[M, ?]] {
       def point[A](a: => A): Tree[M, A] =
-        Tree(F.point(Node(a, List())))
+        Tree(Node(a, F.point(List())))
       def ap[A, B](fa: => Tree[M, A])(f: => Tree[M, A => B]): Tree[M, B] =
         // FIX This isn't ideal, but if it's good enough for the Haskell implementation it's good enough for us
         // https://github.com/hedgehogqa/haskell-hedgehog/pull/173
@@ -67,15 +71,16 @@ object Tree extends TreeImplicits2 {
         fa.map(f)
       override def point[A](a: => A): Tree[M, A] =
         TreeApplicative(F).point(a)
-      override def bind[A, B](fa: Tree[M, A])(f: A => Tree[M, B]): Tree[M, B] =
-        Tree(F.bind(fa.run)(x =>
-          F.bind(f(x.value).run)(y =>
-            F.point(Node(y.value, x.children.map(_.flatMap(f)) ++ y.children))
-          )))
+      override def bind[A, B](fa: Tree[M, A])(f: A => Tree[M, B]): Tree[M, B] = {
+        val y = f(fa.run.value).run
+        Tree(
+          Node(y.value, F.bind(fa.run.children)(x => F.map(y.children)(ys => x.map(_.flatMap(f)) ++ ys)))
+        )
+      }
     }
 
   def unfoldTree[M[_], A, B](f: B => A, g: B => List[B], x: B)(implicit F: Applicative[M]): Tree[M, A] =
-    Tree(F.point(Node(f(x), unfoldForest(f, g, x))))
+    Tree(Node(f(x), F.point(unfoldForest(f, g, x))))
 
   def unfoldForest[M[_], A, B](f: B => A, g: B => List[B], x: B)(implicit F: Applicative[M]): List[Tree[M, A]] =
     g(x).map(y => unfoldTree(f, g, y)(F))

--- a/doc/haskell-differences.md
+++ b/doc/haskell-differences.md
@@ -5,6 +5,7 @@ This page documents where the Scala Hedgehog API deviates significantly from the
 
 - [Result](#result)
   - [Property Plus Example](#property-plus-example)
+- [Monadic Gen](#monadic-gen)
 
 ## Result
 
@@ -85,3 +86,17 @@ Here is an example of re-using the same method with both a property and a "golde
     , example(propReverse.test(List('a', 'b', 'c')))
     )
 ```
+
+
+## Monadic Gen
+
+One of the original goals of the Haskell implementation was to support completely generic monadic values.
+
+> Generators allow monadic effects.
+
+For example you could use a `StateT` as part of the generator. In a strict language like Scala the Monad is also
+_critical_ for providing a lazy tree. However, putting the laziness on _each_ tree node results in _serious_ memory
+problems. For now we have had to move this laziness to the tree children.
+
+In practice I doubt that many people are seriously using monadic effects for generated values, and I'm happy to revisit
+this if/when an issue is raised.

--- a/test/src/test/scala/hedgehog/GenTest.scala
+++ b/test/src/test/scala/hedgehog/GenTest.scala
@@ -21,8 +21,8 @@ object GenTest extends Properties {
 
   def testFrequency: Result = {
     val g = Gen.frequency1((1, Gen.constant("a")), (1, Gen.constant("b")))
-    val r1 = g.run(Size(1), Seed.fromLong(3)).run.value.value._2
-    val r2 = g.run(Size(1), Seed.fromLong(1)).run.value.value._2
+    val r1 = g.run(Size(1), Seed.fromLong(3)).run.value._2
+    val r2 = g.run(Size(1), Seed.fromLong(1)).run.value._2
 
     r1 ==== Some("a") and r2 ==== Some("b")
   }

--- a/test/src/test/scala/hedgehog/GenTest.scala
+++ b/test/src/test/scala/hedgehog/GenTest.scala
@@ -21,8 +21,8 @@ object GenTest extends Properties {
 
   def testFrequency: Result = {
     val g = Gen.frequency1((1, Gen.constant("a")), (1, Gen.constant("b")))
-    val r1 = g.run(Size(1), Seed.fromLong(3)).run.value._2
-    val r2 = g.run(Size(1), Seed.fromLong(1)).run.value._2
+    val r1 = g.run(Size(1), Seed.fromLong(3)).value._2
+    val r2 = g.run(Size(1), Seed.fromLong(1)).value._2
 
     r1 ==== Some("a") and r2 ==== Some("b")
   }


### PR DESCRIPTION
@jystic @thumphries @nhibberd @moodmosaic @Kevin-Lee 

This improves the memory usage _significantly. Goes from requiring > 1g to < 64m. I'm curious what happens in Haskell land but obviously the compiler optimisations are more useful there.