### PR TITLE
Specialise Identity for report/takeSmallest for performance

### DIFF
--- a/core/src/main/scala/hedgehog/Property.scala
+++ b/core/src/main/scala/hedgehog/Property.scala
@@ -32,10 +32,10 @@ trait PropertyTOps[M[_]] extends PropertyTReporting[M] {
   def error[A](e: Exception)(implicit F: Monad[M]): PropertyT[M, A] =
     writeLog(Error(e)).flatMap(_ => failureA[A])
 
-  def check(config: PropertyConfig, p: PropertyT[Identity, Result], seed: Seed): Identity[Report] =
+  def check(config: PropertyConfig, p: PropertyT[Identity, Result], seed: Seed): Report =
     propertyT.report(config, None, seed, p)
 
-  def checkRandom(config: PropertyConfig, p: PropertyT[Identity, Result]): Identity[Report] =
+  def checkRandom(config: PropertyConfig, p: PropertyT[Identity, Result]): Report =
     // FIX: predef MonadIO
     check(config, p, Seed.fromTime())
 }

--- a/core/src/main/scala/hedgehog/Property.scala
+++ b/core/src/main/scala/hedgehog/Property.scala
@@ -32,10 +32,10 @@ trait PropertyTOps[M[_]] extends PropertyTReporting[M] {
   def error[A](e: Exception)(implicit F: Monad[M]): PropertyT[M, A] =
     writeLog(Error(e)).flatMap(_ => failureA[A])
 
-  def check(config: PropertyConfig, p: PropertyT[M, Result], seed: Seed)(implicit F: Monad[M]): M[Report] =
+  def check(config: PropertyConfig, p: PropertyT[Identity, Result], seed: Seed): Identity[Report] =
     propertyT.report(config, None, seed, p)
 
-  def checkRandom(config: PropertyConfig, p: PropertyT[M, Result])(implicit F: Monad[M]): M[Report] =
+  def checkRandom(config: PropertyConfig, p: PropertyT[Identity, Result]): Identity[Report] =
     // FIX: predef MonadIO
     check(config, p, Seed.fromTime())
 }

--- a/core/src/main/scala/hedgehog/core/PropertyT.scala
+++ b/core/src/main/scala/hedgehog/core/PropertyT.scala
@@ -118,7 +118,7 @@ trait PropertyTReporting[M[_]] {
         }
     }
 
-  def report(config: PropertyConfig, size0: Option[Size], seed0: Seed, p: PropertyT[Identity, Result]): Identity[Report] = {
+  def report(config: PropertyConfig, size0: Option[Size], seed0: Seed, p: PropertyT[Identity, Result]): Report = {
     // Increase the size proportionally to the number of tests to ensure better coverage of the desired range
     val sizeInc = Size(Math.max(1, Size.max / config.testLimit.value))
     // Start the size at whatever remainder we have to ensure we run with "max" at least once
@@ -147,10 +147,10 @@ trait PropertyTReporting[M[_]] {
               loop(successes.inc, discards, size.incBy(sizeInc), x.value._1)
         }
       }
-    Identity(loop(SuccessCount(0), DiscardCount(0), size0.getOrElse(sizeInit), seed0))
+    loop(SuccessCount(0), DiscardCount(0), size0.getOrElse(sizeInit), seed0)
   }
 
-  def recheck(config: PropertyConfig, size: Size, seed: Seed)(p: PropertyT[Identity, Result]): Identity[Report] =
+  def recheck(config: PropertyConfig, size: Size, seed: Seed)(p: PropertyT[Identity, Result]): Report =
     report(config.copy(testLimit = SuccessCount(1)), Some(size), seed, p)
 }
 

--- a/core/src/main/scala/hedgehog/predef/IntegralPlus.scala
+++ b/core/src/main/scala/hedgehog/predef/IntegralPlus.scala
@@ -14,7 +14,7 @@ object IntegralPlus {
     new IntegralPlus[Byte] {
 
       override def toBigInt(a: Byte): BigInt =
-        BigInt(a)
+        BigInt(a.toInt)
 
       override def fromBigInt(a: BigInt): Byte =
         a.toByte
@@ -24,7 +24,7 @@ object IntegralPlus {
     new IntegralPlus[Short] {
 
       override def toBigInt(a: Short): BigInt =
-        BigInt(a)
+        BigInt(a.toInt)
 
       override def fromBigInt(a: BigInt): Short =
         a.toShort

--- a/core/src/main/scala/hedgehog/predef/package.scala
+++ b/core/src/main/scala/hedgehog/predef/package.scala
@@ -16,16 +16,17 @@ package object predef {
   def some[A](a: A): Option[A] =
     Some(a)
 
-  def findMapM[M[_], A, B](fa: LazyList[A])(f: A => M[Option[B]])(implicit F: Monad[M]): M[Option[B]] = {
+  @annotation.tailrec
+  def findMap[M[_], A, B](fa: LazyList[A])(f: A => Option[B]): Option[B] = {
     fa match {
       case LazyList.Nil() =>
-        F.point(None)
+        None
       case LazyList.Cons(h, t) =>
-        F.bind(f(h())) {
+        f(h()) match {
           case Some(b) =>
-            F.point(Some(b))
+            Some(b)
           case None =>
-            findMapM(t())(f)
+            findMap(t())(f)
         }
     }
   }

--- a/runner/src/main/scala/hedgehog/runner/Properties.scala
+++ b/runner/src/main/scala/hedgehog/runner/Properties.scala
@@ -12,7 +12,7 @@ abstract class Properties {
     val config = PropertyConfig.default
     val seed = Seed.fromTime()
     tests.foreach(t => {
-      val report = Property.check(t.withConfig(config), t.result, seed).value
+      val report = Property.check(t.withConfig(config), t.result, seed)
       println(Test.renderReport(this.getClass.getName, t, report, ansiCodesSupported = true))
     })
   }

--- a/sbt-test/src/main/scala/hedgehog/sbt/Framework.scala
+++ b/sbt-test/src/main/scala/hedgehog/sbt/Framework.scala
@@ -71,7 +71,7 @@ class Task(
         c.getDeclaredConstructor().newInstance()
     properties.tests.foreach(t => {
       val startTime = System.currentTimeMillis
-      val report = Property.check(t.withConfig(config), t.result, seed).value
+      val report = Property.check(t.withConfig(config), t.result, seed)
       val endTime = System.currentTimeMillis
       eventHandler.handle(Event.fromReport(taskDef, new sbtt.TestSelector(t.name), report, endTime - startTime))
 

--- a/test/src/test/scala/hedgehog/ErrorTest.scala
+++ b/test/src/test/scala/hedgehog/ErrorTest.scala
@@ -15,7 +15,7 @@ object ErrorTest extends Properties {
   def noGen: Result = {
     val e = new RuntimeException()
     val prop = Test("", throw e)
-    val r = Property.checkRandom(PropertyConfig.default, prop.result).value
+    val r = Property.checkRandom(PropertyConfig.default, prop.result)
     getErrorLog(r.status) ==== List(Error(e))
   }
 
@@ -24,7 +24,7 @@ object ErrorTest extends Properties {
     val p = Gen.int(Range.linear(0, 100)).forAll.map(i =>
       if (i > 5) throw e else Result.success
     )
-    val r = Property.checkRandom(PropertyConfig.default, p).value
+    val r = Property.checkRandom(PropertyConfig.default, p)
     getErrorLog(r.status) ==== List(Info("6"), Error(e))
   }
 
@@ -33,7 +33,7 @@ object ErrorTest extends Properties {
     val p = Gen.int(Range.linear(0, 100)).forAll.flatMap(i =>
       if (i > 5) throw e else Property.point(Result.success)
     )
-    val r = Property.checkRandom(PropertyConfig.default, p).value
+    val r = Property.checkRandom(PropertyConfig.default, p)
     getErrorLog(r.status) ==== List(Info("6"), Error(e))
   }
 

--- a/test/src/test/scala/hedgehog/GenTest.scala
+++ b/test/src/test/scala/hedgehog/GenTest.scala
@@ -28,12 +28,12 @@ object GenTest extends Properties {
   }
 
   def testFromSomeSome: Result = {
-    val r = Property.checkRandom(PropertyConfig.default, Gen.fromSome(Gen.constant(Result.success).option).forAll).value
+    val r = Property.checkRandom(PropertyConfig.default, Gen.fromSome(Gen.constant(Result.success).option).forAll)
     r ==== Report(SuccessCount(100), DiscardCount(0), OK)
   }
 
   def testFromSomeNone: Result = {
-    val r = Property.checkRandom(PropertyConfig.default, Gen.fromSome(Gen.constant(Option.empty[Result])).forAll).value
+    val r = Property.checkRandom(PropertyConfig.default, Gen.fromSome(Gen.constant(Option.empty[Result])).forAll)
     r ==== Report(SuccessCount(0), DiscardCount(100), GaveUp)
   }
 }

--- a/test/src/test/scala/hedgehog/PropertyTest.scala
+++ b/test/src/test/scala/hedgehog/PropertyTest.scala
@@ -19,7 +19,7 @@ object PropertyTest extends Properties {
       x <- Gen.char('a', 'z').log("x")
       y <- int(Range.linear(0, 50)).log("y")
       _ <- if (y % 2 == 0) Property.discard else Property.point(())
-    } yield Result.assert(y < 87 && x <= 'r'), seed).value
+    } yield Result.assert(y < 87 && x <= 'r'), seed)
     r ==== Report(SuccessCount(2), DiscardCount(4), Failed(ShrinkCount(2), List(
         ForAll("x", "s")
       , ForAll("y", "1"))
@@ -64,7 +64,7 @@ object PropertyTest extends Properties {
       x <- order(cheap).log("cheap")
       y <- order(expensive).log("expensive")
     } yield Result.assert(merge(x, y).total.value == x.total.value + y.total.value)
-      , seed).value
+      , seed)
     r ==== Report(SuccessCount(1), DiscardCount(0), Failed(ShrinkCount(4), List(
         ForAll("cheap", "Order(List())")
       , ForAll("expensive", "Order(List(Item(oculus,USD(1000))))"
@@ -72,5 +72,5 @@ object PropertyTest extends Properties {
   }
 
   def fail: Result =
-    Property.checkRandom(PropertyConfig.default, Property.point(Result.failure)).value.status ==== Failed(ShrinkCount(0), Nil)
+    Property.checkRandom(PropertyConfig.default, Property.point(Result.failure)).status ==== Failed(ShrinkCount(0), Nil)
 }

--- a/test/src/test/scala/hedgehog/ShrinkTest.scala
+++ b/test/src/test/scala/hedgehog/ShrinkTest.scala
@@ -30,7 +30,7 @@ object ShrinkTest extends Properties {
         failed = failed + 1
       }
       Result.assert(b)
-    }, Seed.fromTime()).value
+    }, Seed.fromTime())
 
     r.status match {
       case Failed(s, _) =>


### PR DESCRIPTION
@jystic @moodmosaic 

This removes some final memory performance issues for large generators and lots of shrinking. Previously my machine would lock up and eventually run out of JVM memory.

This will really force another bigger change, which is to remove the `M` from Gen/Tree entirely. More on that on the next PR, but I think it's not adding much to the scala version, I doubt anyone will ever use it, and worse and I think it will deter lots of non-Haskell users.