### PR TITLE
Remove higher kind from Gen/Property/Tree

### DIFF
--- a/core/src/main/scala/hedgehog/core/PropertyR.scala
+++ b/core/src/main/scala/hedgehog/core/PropertyR.scala
@@ -1,24 +1,22 @@
 package hedgehog.core
 
-import hedgehog.predef._
-
 /**
  * A slightly different way to express a property, with the added benefit of exposing a pure "test".
  * This enables running the test with specific examples, either as a "golden" test or from the shell. Or both.
  * The trade-off is that the `A` needs to be exposed/declared, and it's likely to be some horrible multi-value tuple.
  */
 class PropertyR[A](
-    val gen : PropertyT[Identity, A]
+    val gen : PropertyT[A]
   , val test: A => Result
   ) {
 
-  def property: PropertyT[Identity, Result] =
+  def property: PropertyT[Result] =
     gen.map(test)
 }
 
 object PropertyR {
 
   /** Constructor function with split arguments to help type-inference */
-  def apply[A](gen: PropertyT[Identity, A])(test: A => Result): PropertyR[A] =
+  def apply[A](gen: PropertyT[A])(test: A => Result): PropertyR[A] =
     new PropertyR[A](gen, test)
 }

--- a/core/src/main/scala/hedgehog/core/PropertyT.scala
+++ b/core/src/main/scala/hedgehog/core/PropertyT.scala
@@ -35,11 +35,11 @@ object PropertyConfig {
     PropertyConfig(SuccessCount(100), DiscardCount(100), ShrinkLimit(1000))
 }
 
-case class PropertyT[M[_], A](
-    run: GenT[M, (List[Log], Option[A])]
+case class PropertyT[A](
+    run: GenT[(List[Log], Option[A])]
   ) {
 
-  def map[B](f: A => B)(implicit F: Monad[M]): PropertyT[M, B] =
+  def map[B](f: A => B): PropertyT[B] =
     copy(run = run.map(x =>
       try {
         x.copy(_2 = x._2.map(f))
@@ -51,10 +51,10 @@ case class PropertyT[M[_], A](
       }
     ))
 
-  def flatMap[B](f: A => PropertyT[M, B])(implicit F: Monad[M]): PropertyT[M, B] =
+  def flatMap[B](f: A => PropertyT[B]): PropertyT[B] =
     copy(run = run.flatMap(x =>
       x._2.fold(
-       GenT.GenApplicative(F).point((x._1, Option.empty[B]))
+       GenT.GenApplicative.point((x._1, Option.empty[B]))
       )(a =>
         try {
           f(a).run.map(y => (x._1 ++ y._1, y._2))
@@ -62,7 +62,7 @@ case class PropertyT[M[_], A](
           // Forgive me, I'm assuming this breaks the Monad laws
           // If there's a better and non-law breaking of handling this we should remove this
           case e: Exception =>
-            genT.constant((x._1 ++ List(Error(e)), None))
+            Gen.constant((x._1 ++ List(Error(e)), None))
         }
       )
     ))
@@ -70,21 +70,21 @@ case class PropertyT[M[_], A](
 
 object PropertyT {
 
-  implicit def PropertyMonad[M[_]](implicit F: Monad[M]): Monad[PropertyT[M, ?]] =
-    new Monad[PropertyT[M, ?]] {
-      override def map[A, B](fa: PropertyT[M, A])(f: A => B): PropertyT[M, B] =
+  implicit def PropertyMonad[M[_]]: Monad[PropertyT[?]] =
+    new Monad[PropertyT[?]] {
+      override def map[A, B](fa: PropertyT[A])(f: A => B): PropertyT[B] =
         fa.map(f)
-      override def point[A](a: => A): PropertyT[M, A] =
+      override def point[A](a: => A): PropertyT[A] =
         propertyT.hoist((Nil, a))
-      override def bind[A, B](fa: PropertyT[M, A])(f: A => PropertyT[M, B]): PropertyT[M, B] =
+      override def bind[A, B](fa: PropertyT[A])(f: A => PropertyT[B]): PropertyT[B] =
         fa.flatMap(f)
     }
 }
 
-trait PropertyTReporting[M[_]] {
+trait PropertyTReporting {
 
   @annotation.tailrec
-  final def takeSmallest(n: ShrinkCount, slimit: ShrinkLimit, t: Tree[Identity, Option[(List[Log], Option[Result])]]): Status =
+  final def takeSmallest(n: ShrinkCount, slimit: ShrinkLimit, t: Tree[Option[(List[Log], Option[Result])]]): Status =
     t.value match {
       case None =>
         Status.gaveUp
@@ -118,7 +118,7 @@ trait PropertyTReporting[M[_]] {
         }
     }
 
-  def report(config: PropertyConfig, size0: Option[Size], seed0: Seed, p: PropertyT[Identity, Result]): Report = {
+  def report(config: PropertyConfig, size0: Option[Size], seed0: Seed, p: PropertyT[Result]): Report = {
     // Increase the size proportionally to the number of tests to ensure better coverage of the desired range
     val sizeInc = Size(Math.max(1, Size.max / config.testLimit.value))
     // Start the size at whatever remainder we have to ensure we run with "max" at least once
@@ -150,7 +150,7 @@ trait PropertyTReporting[M[_]] {
     loop(SuccessCount(0), DiscardCount(0), size0.getOrElse(sizeInit), seed0)
   }
 
-  def recheck(config: PropertyConfig, size: Size, seed: Seed)(p: PropertyT[Identity, Result]): Report =
+  def recheck(config: PropertyConfig, size: Size, seed: Seed)(p: PropertyT[Result]): Report =
     report(config.copy(testLimit = SuccessCount(1)), Some(size), seed, p)
 }
 

--- a/core/src/main/scala/hedgehog/core/Tree.scala
+++ b/core/src/main/scala/hedgehog/core/Tree.scala
@@ -10,43 +10,43 @@ import hedgehog.predef._
  * The alternative might be something like:
  * https://github.com/hedgehogqa/scala-hedgehog/compare/topic/issue-66-lazy-shrinking
  */
-case class Tree[M[_], A](value: A, children: M[LazyList[Tree[M, A]]]) {
+case class Tree[A](value: A, children: Identity[LazyList[Tree[A]]]) {
 
-  def map[B](f: A => B)(implicit F: Functor[M]): Tree[M, B] =
-    Tree.TreeFunctor[M].map(this)(f)
+  def map[B](f: A => B): Tree[B] =
+    Tree.TreeFunctor.map(this)(f)
 
-  def flatMap[B](f: A => Tree[M, B])(implicit F: Monad[M]): Tree[M, B] =
-    Tree.TreeMonad[M].bind(this)(f)
+  def flatMap[B](f: A => Tree[B]): Tree[B] =
+    Tree.TreeMonad.bind(this)(f)
 
-  def expand(f: A => List[A])(implicit F: Applicative[M]): Tree[M, A] =
+  def expand(f: A => List[A]): Tree[A] =
     Tree(
-      this.value, F.map(this.children)(_.map(_.expand(f)) ++ Tree.unfoldForest(identity[A], f, this.value)(F))
+      this.value, this.children.map(_.map(_.expand(f)) ++ Tree.unfoldForest(identity[A], f, this.value))
     )
 
-  def prune(implicit F: Applicative[M]): Tree[M, A] =
-    Tree(this.value, F.point(LazyList()))
+  def prune: Tree[A] =
+    Tree(this.value, Identity(LazyList()))
 }
 
 abstract class TreeImplicits1 {
 
-  implicit def TreeFunctor[M[_]](implicit F: Functor[M]): Functor[Tree[M, ?]] =
-    new Functor[Tree[M, ?]] {
-      override def map[A, B](fa: Tree[M, A])(f: A => B): Tree[M, B] =
-        Tree(f(fa.value), F.map(fa.children)(_.map(_.map(f))))
+  implicit def TreeFunctor: Functor[Tree] =
+    new Functor[Tree] {
+      override def map[A, B](fa: Tree[A])(f: A => B): Tree[B] =
+        Tree(f(fa.value), fa.children.map(_.map(_.map(f))))
     }
 }
 
 abstract class TreeImplicits2 extends TreeImplicits1 {
 
-  implicit def TreeApplicative[M[_]](implicit F: Monad[M]): Applicative[Tree[M, ?]] =
-    new Applicative[Tree[M, ?]] {
-      def point[A](a: => A): Tree[M, A] =
-        Tree(a, F.point(LazyList()))
-      def ap[A, B](fa: => Tree[M, A])(f: => Tree[M, A => B]): Tree[M, B] =
+  implicit def TreeApplicative: Applicative[Tree] =
+    new Applicative[Tree] {
+      def point[A](a: => A): Tree[A] =
+        Tree(a, Identity(LazyList()))
+      def ap[A, B](fa: => Tree[A])(f: => Tree[A => B]): Tree[B] =
         // FIX This isn't ideal, but if it's good enough for the Haskell implementation it's good enough for us
         // https://github.com/hedgehogqa/haskell-hedgehog/pull/173
-        Tree.TreeMonad[M].bind(f)(ab =>
-        Tree.TreeMonad[M].bind(fa)(a =>
+        Tree.TreeMonad.bind(f)(ab =>
+        Tree.TreeMonad.bind(fa)(a =>
           point(ab(a))
         ))
     }
@@ -54,24 +54,24 @@ abstract class TreeImplicits2 extends TreeImplicits1 {
 
 object Tree extends TreeImplicits2 {
 
-  implicit def TreeMonad[M[_]](implicit F: Monad[M]): Monad[Tree[M, ?]] =
-    new Monad[Tree[M, ?]] {
-      override def map[A, B](fa: Tree[M, A])(f: A => B): Tree[M, B] =
+  implicit def TreeMonad: Monad[Tree] =
+    new Monad[Tree] {
+      override def map[A, B](fa: Tree[A])(f: A => B): Tree[B] =
         fa.map(f)
-      override def point[A](a: => A): Tree[M, A] =
-        TreeApplicative(F).point(a)
-      override def bind[A, B](fa: Tree[M, A])(f: A => Tree[M, B]): Tree[M, B] = {
+      override def point[A](a: => A): Tree[A] =
+        TreeApplicative.point(a)
+      override def bind[A, B](fa: Tree[A])(f: A => Tree[B]): Tree[B] = {
         val y = f(fa.value)
         Tree(
-          y.value, F.bind(fa.children)(x => F.map(y.children)(ys => x.map(_.flatMap(f)) ++ ys))
+          y.value, fa.children.flatMap(x => y.children.map(ys => x.map(_.flatMap(f)) ++ ys))
         )
       }
     }
 
-  def unfoldTree[M[_], A, B](f: B => A, g: B => List[B], x: B)(implicit F: Applicative[M]): Tree[M, A] =
-    Tree(f(x), F.point(unfoldForest(f, g, x)))
+  def unfoldTree[M[_], A, B](f: B => A, g: B => List[B], x: B): Tree[A] =
+    Tree(f(x), Identity(unfoldForest(f, g, x)))
 
-  def unfoldForest[M[_], A, B](f: B => A, g: B => List[B], x: B)(implicit F: Applicative[M]): LazyList[Tree[M, A]] =
-    LazyList.fromList(g(x).map(y => unfoldTree(f, g, y)(F)))
+  def unfoldForest[M[_], A, B](f: B => A, g: B => List[B], x: B): LazyList[Tree[A]] =
+    LazyList.fromList(g(x).map(y => unfoldTree(f, g, y)))
 }
 

--- a/core/src/main/scala/hedgehog/extra/Byte.scala
+++ b/core/src/main/scala/hedgehog/extra/Byte.scala
@@ -2,18 +2,17 @@ package hedgehog.extra
 
 import hedgehog.Range
 import hedgehog.core.GenT
-import hedgehog.predef._
 
-trait ByteOps[M[_]] {
+trait ByteOps {
 
-  private val genT = new hedgehog.GenTOps[M] with CharacterOps[M] {}
+  private val genT = new hedgehog.GenTOps with CharacterOps {}
 
   /**
    * Generates a random 'Array[Byte]', using 'Range' to determine the length.
    *
    * _Shrinks down to the ascii characters._
    */
-  def bytes(range: Range[Int])(implicit F: Monad[M]): GenT[M, Array[Byte]] =
+  def bytes(range: Range[Int]): GenT[Array[Byte]] =
     genT.choice1(
       genT.ascii.map(_.toByte)
     , genT.byte(Range.constant(java.lang.Byte.MIN_VALUE, java.lang.Byte.MAX_VALUE))

--- a/core/src/main/scala/hedgehog/extra/Character.scala
+++ b/core/src/main/scala/hedgehog/extra/Character.scala
@@ -1,26 +1,25 @@
 package hedgehog.extra
 
 import hedgehog.core.GenT
-import hedgehog.predef._
 
-trait CharacterOps[M[_]] {
+trait CharacterOps {
 
-  private val genT = new hedgehog.GenTOps[M] {}
+  private val genT = new hedgehog.GenTOps {}
 
   /** Generates an ASCII binit: '0' to '1' */
-  def binit(implicit F: Monad[M]): GenT[M, Char] =
+  def binit: GenT[Char] =
     genT.char('0', '1')
 
   /** Generates an ASCII octit: '0' to '7' */
-  def octit(implicit F: Monad[M]): GenT[M, Char] =
+  def octit: GenT[Char] =
     genT.char('0', '7')
 
   /** Generates an ASCII digit: '0' to '9' */
-  def digit(implicit F: Monad[M]): GenT[M, Char] =
+  def digit: GenT[Char] =
     genT.char('0', '9')
 
   /** Generates an ASCII hexit: '0' to '9', 'a' to 'f', 'A' to 'F' */
-  def hexit(implicit F: Monad[M]): GenT[M, Char] =
+  def hexit: GenT[Char] =
     genT.choice1(
       genT.char('0', '9')
     , genT.char('a', 'f')
@@ -28,37 +27,37 @@ trait CharacterOps[M[_]] {
     )
 
   /** Generates an ASCII lowercase letter: 'a' to 'z' */
-  def lower(implicit F: Monad[M]): GenT[M, Char] =
+  def lower: GenT[Char] =
     genT.char('a', 'z')
 
   /** Generates an ASCII uppercase letter: 'A' to 'Z' */
-  def upper(implicit F: Monad[M]): GenT[M, Char] =
+  def upper: GenT[Char] =
     genT.char('A', 'Z')
 
   /** Generates an ASCII letter: 'a' to 'z', 'A' to 'Z' */
-  def alpha(implicit F: Monad[M]): GenT[M, Char] =
+  def alpha: GenT[Char] =
     genT.choice1(lower, upper)
 
   /** Generates an ASCII letter or digit: 'a' to 'z', 'A' to 'Z', '0' to '9' */
-  def alphaNum(implicit F: Monad[M]): GenT[M, Char] =
+  def alphaNum: GenT[Char] =
     genT.choice1(alpha, digit)
 
   /** Generates an ASCII character */
-  def ascii(implicit F: Monad[M]): GenT[M, Char] =
+  def ascii: GenT[Char] =
     genT.char(0, 125)
 
   /** Generates an Latin-1 character */
-  def latin1(implicit F: Monad[M]): GenT[M, Char] =
+  def latin1: GenT[Char] =
     genT.char(0, 255)
 
   /** Generates a Unicode character, excluding noncharacters and invalid standalone surrogates: */
-  def unicode(implicit F: Monad[M]): GenT[M, Char] =
+  def unicode: GenT[Char] =
     unicodeAll
       .filter(!isSurrogate(_))
       .filter(!isNoncharacter(_))
 
   /** Generates a Unicode character, including noncharacters and invalid standalone surrogates */
-  def unicodeAll(implicit F: Monad[M]): GenT[M, Char] =
+  def unicodeAll: GenT[Char] =
     genT.char(0, Integer.MAX_VALUE.toChar)
 
   /** Check if a character is in the surrogate category. */

--- a/core/src/main/scala/hedgehog/extra/String.scala
+++ b/core/src/main/scala/hedgehog/extra/String.scala
@@ -2,13 +2,12 @@ package hedgehog.extra
 
 import hedgehog.Range
 import hedgehog.core.GenT
-import hedgehog.predef._
 
-trait StringOps[M[_]] {
+trait StringOps {
 
   /**
    * Generates a string using 'Range' to determine the length.
    */
-  def string(gen: GenT[M, Char], range: Range[Int])(implicit F: Monad[M]): GenT[M, String] =
+  def string(gen: GenT[Char], range: Range[Int]): GenT[String] =
     gen.list(range).map(_.mkString)
 }

--- a/core/src/main/scala/hedgehog/package.scala
+++ b/core/src/main/scala/hedgehog/package.scala
@@ -4,27 +4,19 @@ import hedgehog.predef.ApplicativeSyntax
 
 package object hedgehog extends ApplicativeSyntax {
 
-  type HM[A] = predef.Identity[A]
-
   /**
    * This is _purely_ to make consuming this library a nicer experience,
    * mainly due to Scala's type inference problems and higher kinds.
    */
   object Gen
-    extends GenTOps[HM]
-    with ByteOps[HM]
-    with CharacterOps[HM]
-    with StringOps[HM]
-  type Gen[A] = GenT[HM, A]
+    extends GenTOps
+    with ByteOps
+    with CharacterOps
+    with StringOps
+  type Gen[A] = GenT[A]
 
-  def genT[M[_]] =
-    new GenTOps[M]
-    with ByteOps[M]
-    with CharacterOps[M]
-    with StringOps[M] {}
-
-  type Property = PropertyT[HM, Result]
-  object Property extends PropertyTOps[HM]
+  type Property = PropertyT[Result]
+  object Property extends PropertyTOps
 
   type PropertyR[A] = core.PropertyR[A]
   val PropertyR = core.PropertyR
@@ -32,8 +24,8 @@ package object hedgehog extends ApplicativeSyntax {
   type Result = hedgehog.core.Result
   val Result = hedgehog.core.Result
 
-  def propertyT[M[_]]: PropertyTOps[M] =
-    new PropertyTOps[M] {}
+  def propertyT[M[_]]: PropertyTOps =
+    new PropertyTOps {}
 
   implicit class Syntax[A](a1: A) {
 

--- a/core/src/main/scala/hedgehog/predef/Identity.scala
+++ b/core/src/main/scala/hedgehog/predef/Identity.scala
@@ -9,6 +9,12 @@ package hedgehog.predef
 abstract class Identity[A] {
 
   def value: A
+
+  def map[B](f: A => B): Identity[B] =
+    Identity(f(value))
+
+  def flatMap[B](f: A => Identity[B]): Identity[B] =
+    Identity(f(value).value)
 }
 
 object Identity {
@@ -17,19 +23,5 @@ object Identity {
     new Identity[A] {
       def value: A =
         a
-    }
-
-  implicit def IdentityMonad: Monad[Identity] =
-    new Monad[Identity] {
-
-      // NOTE: It's critical to override the free Applicative version, otherwise we get stack overflows
-      override def map[A, B](fa: Identity[A])(f: A => B) =
-        Identity(f(fa.value))
-
-      override def point[A](a: => A): Identity[A] =
-        Identity(a)
-
-      override def bind[A, B](fa: Identity[A])(f: A => Identity[B]): Identity[B] =
-        Identity(f(fa.value).value)
     }
 }


### PR DESCRIPTION
@jystic @moodmosaic 

Two main reasons for removing this.

1. It's unlikely that it's actually going to be used by 99.99% of
   users. That is if we had any...

2. To the previous point, removing the kind will hopefully
   increase the chances of not scaring off potential users.