### PR TITLE
Fix scaladoc

### DIFF
--- a/core/src/main/scala/hedgehog/state/Action.scala
+++ b/core/src/main/scala/hedgehog/state/Action.scala
@@ -195,13 +195,10 @@ object Action {
  */
 case class Parallel[S](
 
-    /** The sequential prefix. */
     prefix: List[Action[S]]
 
-    /** The first branch. */
   , branch1: List[Action[S]]
 
-    /** The second branch. */
   , branch2: List[Action[S]]
   )
 

--- a/core/src/main/scala/hedgehog/state/Command.scala
+++ b/core/src/main/scala/hedgehog/state/Command.scala
@@ -19,7 +19,7 @@ trait Command[S, I, O] extends CommandIO[S] {
 
   /**
    * A generator which provides random arguments for a command.
-   * If the command cannot be executed in the current state, it should return [[None]].
+   * If the command cannot be executed in the current state, it should return `None`.
    */
   def gen(s: S): Option[GenT[Input]]
 


### PR DESCRIPTION
Was causing "discarding unmoored doc" errors, but only on publish and without notifications. :(