### PR TITLE
Scala 2.13.0-RC2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ scala:
  - 2.10.7
  - 2.11.12
  - 2.12.8
- - 2.13.0-RC1
+ - 2.13.0-RC2
 script:
   - sbt ++$TRAVIS_SCALA_VERSION 'set version in ThisBuild := "'$(git log --format=%H -1)'"' test
 after_success:

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ lazy val projectSettings = Seq(
   , version in ThisBuild := "1.0.0"
   , organization := "hedgehog"
   , scalaVersion := "2.12.8"
-  , crossScalaVersions := Seq("2.10.7", "2.11.12", scalaVersion.value, "2.13.0-RC1")
+  , crossScalaVersions := Seq("2.10.7", "2.11.12", scalaVersion.value, "2.13.0-RC2")
   , fork in run  := true
   )
 
@@ -106,7 +106,7 @@ lazy val compilationSettings = Seq(
         }
       }
     }
-  , libraryDependencies += compilerPlugin("org.typelevel" %% "kind-projector" % "0.10.0" cross CrossVersion.binary)
+  , libraryDependencies += compilerPlugin("org.typelevel" %% "kind-projector" % "0.10.1" cross CrossVersion.binary)
   )
 
 lazy val testingSettings = Seq(

--- a/sbt
+++ b/sbt
@@ -9,7 +9,7 @@ set -o pipefail
 declare -r sbt_release_version="0.13.17"
 declare -r sbt_unreleased_version="0.13.17"
 
-declare -r latest_213="2.13.0-RC1"
+declare -r latest_213="2.13.0-RC2"
 declare -r latest_212="2.12.8"
 declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.7"


### PR DESCRIPTION
Drops RC1, as most projects seem to be doing.  They both could be maintained with a fancier cross-versioning of kind-projector.