### PR TITLE
Stop using filter to define unicode

### DIFF
--- a/core/src/main/scala/hedgehog/Gen.scala
+++ b/core/src/main/scala/hedgehog/Gen.scala
@@ -137,6 +137,22 @@ trait GenTOps extends MonadGenOps[Gen] {
        x <- pick(n, a, l)
      } yield x
    }
+
+  /**
+    * Uses a weighted distribution to randomly select one of the generators in the list.
+    *
+    * This generator shrinks towards the first generator in the list.
+    *
+    * WARNING: This may throw an exception if the list is empty,
+    * please use one of the other `frequency` variants if possible.
+    */
+  def frequencyUnsafe[A](xs: List[(Int, GenT[A])]): GenT[A] =
+    xs match {
+      case Nil =>
+        sys.error("frequency: used with empty list")
+      case h :: t =>
+        frequency(h, t)
+    }
 }
 
 trait MonadGenOps[M[_]] {

--- a/core/src/main/scala/hedgehog/extra/Character.scala
+++ b/core/src/main/scala/hedgehog/extra/Character.scala
@@ -52,19 +52,12 @@ trait CharacterOps {
 
   /** Generates a Unicode character, excluding noncharacters and invalid standalone surrogates: */
   def unicode: GenT[Char] =
-    unicodeAll
-      .filter(!isSurrogate(_))
-      .filter(!isNoncharacter(_))
+    genT.frequencyUnsafe(
+      List(0 -> 55295, 57344 -> 65533)
+        .map(x => (1 + x._2 - x._1, genT.char(x._1.toChar, x._2.toChar)))
+    )
 
   /** Generates a Unicode character, including noncharacters and invalid standalone surrogates */
   def unicodeAll: GenT[Char] =
     genT.char(0, Integer.MAX_VALUE.toChar)
-
-  /** Check if a character is in the surrogate category. */
-  def isSurrogate(x: Char): Boolean =
-    x >= 55296 && x <= 57343
-
-  /** Check if a character is one of the noncharacters. */
-  def isNoncharacter(x: Char): Boolean =
-    x == 65534 || x == 65535
 }

--- a/test/src/test/scala/hedgehog/extra/CharacterTest.scala
+++ b/test/src/test/scala/hedgehog/extra/CharacterTest.scala
@@ -1,0 +1,21 @@
+package hedgehog.extra
+
+import hedgehog._
+import hedgehog.runner._
+
+object CharacterTest extends Properties {
+
+  def tests: List[Test] =
+    List(
+      property("unicode", testUnicode).withTests(1000)
+    )
+
+  def testUnicode: Property =
+    for {
+      c <- Gen.unicode.forAll
+    } yield
+      Result.all(List(
+        Result.assert(!Character.isSurrogate(c)).log(c.toInt.toString).log("surrogate")
+      , Result.assert(!(c == 65534 || c == 65535)).log("non-character")
+      ))
+}


### PR DESCRIPTION
Prompted by https://github.com/hedgehogqa/haskell-hedgehog/pull/303/files from @ajmcmiddlin.

Didn't like the manual frequencies and noticed ScalaCheck did this https://github.com/rickynils/scalacheck/blob/aadbaa94f724b1a411446ebab83f3360b3245ad9/src/main/scala/org/scalacheck/Arbitrary.scala#L123-L134.