### PR TITLE
Added: diff like Haskell Hedgehog

### DIFF
--- a/core/src/main/scala/hedgehog/core/Result.scala
+++ b/core/src/main/scala/hedgehog/core/Result.scala
@@ -77,4 +77,70 @@ object Result {
 
   def any(l: List[Result]): Result =
     l.foldLeft(Result.failure)(_.or(_))
+
+  /**
+    * Compare two arguments with the comparison function and return Result.success
+    * if the function return true. Otherwise, it returns Result.failure with
+    * the Log containing the argument values.
+    *
+    * @example
+    * {{{
+    *   val a1 = "abc"
+    *   val a2 = "abc"
+    *   Result.diff(a1, a2)(_ == _)
+    *   // Result.success
+    *
+    *   Result.diff(123, 456)(_ != _).log("It must be different.")
+    *   // Result.success
+    *
+    *   val x = 'q'
+    *   val y = 80
+    *   Result.diff(x, y)((x, y) => y < 87 && x <= 'r')
+    *   // Result.success
+    * }}}
+    * @example
+    * {{{
+    *   val a1 = "abc"
+    *   val a2 = "xyz"
+    *   Result.diff(a1, a2)(_ == _)
+    *   // Result.failure
+    *   > === Failed ===
+    *   > --- lhs ---
+    *   > abc
+    *   > --- rhs ---
+    *   > xyz
+    *
+    *   Result.diff(123, 123)(_ != _).log("It must be different.")
+    *   // Result.failure
+    *   > === Failed ===
+    *   > --- lhs ---
+    *   > 123
+    *   > --- rhs ---
+    *   > 123
+    *   > It must be different.
+    *
+    *   val x = 'z'
+    *   val y = 100
+    *   Result.diff(x, y)((x, y) => y < 87 && x <= 'r')
+    *   // Result.failure
+    *   > === Failed ===
+    *   > --- lhs ---
+    *   > z
+    *   > --- rhs ---
+    *   > 100
+    * }}}
+    *
+    * @see https://github.com/hedgehogqa/haskell-hedgehog/blob/921e4af72a181f01d90816fd7055b823bf885b3b/hedgehog/src/Hedgehog/Internal/Property.hs#L707
+    */
+  def diff[A, B](a: A, b: B)(f: (A, B) => Boolean): Result =
+    diffNamed("=== Failed ===", a, b)(f)
+
+  def diffNamed[A, B](logName: String, a: A, b: B)(f: (A, B) => Boolean): Result =
+    assert(f(a, b))
+      .log(logName)
+      .log("--- lhs ---")
+      .log(String.valueOf(a))
+      .log("--- rhs ---")
+      .log(String.valueOf(b))
+
 }

--- a/core/src/main/scala/hedgehog/package.scala
+++ b/core/src/main/scala/hedgehog/package.scala
@@ -33,16 +33,10 @@ package object hedgehog extends ApplicativeSyntax {
 
   implicit class Syntax[A](a1: A) {
 
-     // FIX Is there a way to get this to work with PropertyT and type-inference?
-     def ====(a2: A): Result = {
-       if (a1 == a2)
-         Result.success
-       else
-         Result.failure
-           .log("=== Not Equal ===")
-           .log(a1.toString)
-           .log(a2.toString)
-     }
+    // FIX Is there a way to get this to work with PropertyT and type-inference?
+    def ====(a2: A): Result =
+      Result.diffNamed("=== Not Equal ===", a1, a2)(_ == _)
 
-  }
+}
+
 }

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -86,7 +86,9 @@ Check it!
 - Spec$.property: Falsified after 8 passed tests
 > -1
 > === Not Equal ===
+> --- lhs ---
 > 1.0
+> --- rhs ---
 > -1.0
 ```
 
@@ -180,15 +182,66 @@ def testAdd: Result =
 ```
 
 ```
-Spec$.add: Falsified after 1 passed tests
+Spec$.testAdd: Falsified after 1 passed tests
 > === Not Equal ===
+> --- lhs ---
 > 3
+> --- rhs ---
 > 7
 ```
 
 That's a little better. But what happens if we don't just want to check
 equality?
 
+There is a method called `diff` which is similar to `Result.assert` but it gives the similar message to `====` operator's.
+
+`diff` takes two arguments and the comparison function so that you can do any comparison operation you want on those two arguments.
+
+```scala
+def testAdd: Result =
+  Result.diff(1 + 2, 3 + 4)(_ == _)
+```
+
+```
+Spec$.testAdd: Falsified after 1 passed tests
+> === Failed ===
+> --- lhs ---
+> 3
+> --- rhs ---
+> 7
+```
+*** 
+```scala
+def a1GtA2: Result =
+  Result.diff(1 + 2, 3 + 4)(_ > _)
+```
+
+```
+Spec$.a1GtA2: Falsified after 0 passed tests
+> === Failed ===
+> --- lhs ---
+> 3
+> --- rhs ---
+> 7
+```
+
+If you want to change the log name (i.e. `=== Failed ===`) to something else, you can use `diffNamed` instead.
+
+e.g.)
+
+```scala
+Result.diffNamed("=== Not Equal ===", 1 + 2, 3 + 4)(_ == _)
+```
+```
+Spec$.testAdd: Falsified after 1 passed tests
+> === Not Equal ===
+> --- lhs ---
+> 3
+> --- rhs ---
+> 7
+```
+
+In fact, `====` internally uses the `diffNamed` method.
 
 #### Logging
 
@@ -547,7 +600,9 @@ Now, run the tests:
 - Spec$.example: Falsified after 5 passed tests
 > l: List(0,0)
 > === Not Equal ===
+> --- lhs ---
 > List(0,0)
+> --- rhs ---
 > List(0)
 ```
 


### PR DESCRIPTION
Add `diff` like Haskell's Hedgehog.
https://github.com/hedgehogqa/haskell-hedgehog/blob/921e4af72a181f01d90816fd7055b823bf885b3b/hedgehog/src/Hedgehog/Internal/Property.hs#L707

```scala
diff("abc", "abc")(_ == _)
```

I'm not so sure about the name `diffNamed`. I added it to have `=== Not Equal ===` for `====` operator.

As we already discussed, I couldn't have the comparison function in between due to `missing parameter type` issue.

e.g.)
```scala
def diff[A](a1: => A, f: (A, A) => Boolean, a2: => A): Result
```
```scala
diff("abc", _ == _, "abc")
```
```
scala-hedgehog/test/src/test/scala/hedgehog/PropertyTest.scala:21:17: missing parameter type for expanded function ((x$1: <error>, x$2) => x$1.$eq$eq(x$2))
    diff("abc", _ == _, "abc")
                ^
scala-hedgehog/test/src/test/scala/hedgehog/PropertyTest.scala:21:22: missing parameter type for expanded function ((x$1: <error>, x$2: <error>) => x$1.$eq$eq(x$2))
    diff("abc", _ == _, "abc")
                     ^
```

Another possibility is using currying, yet I'm not sure if it is good to have three parentheses.
```scala
def diff[A](a1: => A)(f: (A, A) => Boolean)(a2: => A): Result
```
```scala
diff("abc")(_ == _)("abc")
```
