### PR TITLE
Add defaults implementation for command vars/require

### DIFF
--- a/core/src/main/scala/hedgehog/state/Command.scala
+++ b/core/src/main/scala/hedgehog/state/Command.scala
@@ -15,7 +15,8 @@ trait Command[S, I, O] extends CommandIO[S] {
    *
    * Failure to do this correctly will result in missing variable errors during shrinking.
    */
-  def vars(i: Input): List[Var[_]]
+  def vars(i: Input): List[Var[_]] =
+    Nil
 
   /**
    * A generator which provides random arguments for a command.
@@ -33,7 +34,8 @@ trait Command[S, I, O] extends CommandIO[S] {
    * This is mainly used during shrinking to ensure that it is still OK to run a command
    * despite the fact that some previously executed commands may have been removed from the sequence.
    */
-  def require(s: S, i: Input): Boolean
+  def require(s: S, i: Input): Boolean =
+    true
 
   /**
    * Updates the model state, given the input and output of the command.

--- a/example/src/main/scala/hedgehog/examples/state/RegistryTest.scala
+++ b/example/src/main/scala/hedgehog/examples/state/RegistryTest.scala
@@ -94,9 +94,6 @@ object Spawn {
   def command(pid: AtomicReference[Pid]): CommandIO[State] =
     new Command[State, Spawn, Pid] {
 
-      override def vars(i: Spawn): List[Var[_]] =
-        Nil
-
       override def gen(s: State): Option[Gen[Spawn]] =
         Some(Gen.constant(Spawn()))
 
@@ -105,9 +102,6 @@ object Spawn {
           def apply(x: Pid): Pid =
             Pid(x.value + 1)
         }))
-
-      def require(state: State, input: Spawn): Boolean =
-        true
 
       def update(s: State, i: Spawn, o: Var[Pid]): State =
         s.copy(pids = s.pids + o)
@@ -149,7 +143,7 @@ object Register {
             Right(())
         }
 
-      def require(state: State, input: Register): Boolean =
+      override def require(state: State, input: Register): Boolean =
         !state.regs.contains(input.name) && !state.regs.exists(x => x._2 == input.value)
 
       def update(s: State, i: Register, o: Var[Unit]): State =
@@ -167,9 +161,6 @@ object Unregister {
   def command(procTable: concurrent.Map[Name, Pid]): CommandIO[State] =
     new Command[State, Unregister, Unit] {
 
-      override def vars(i: Unregister): List[Var[_]] =
-        Nil
-
       override def gen(s: State): Option[Gen[Unregister]] =
         s.regs.keys.toList match {
           case Nil =>
@@ -186,7 +177,7 @@ object Unregister {
             Right(())
         }
 
-      def require(state: State, input: Unregister): Boolean =
+      override def require(state: State, input: Unregister): Boolean =
         state.regs.contains(input.name)
 
       def update(s: State, i: Unregister, o: Var[Unit]): State =

--- a/test/src/test/scala/hedgehog/state/StateTest.scala
+++ b/test/src/test/scala/hedgehog/state/StateTest.scala
@@ -141,9 +141,6 @@ object Registry {
   def spawnCommand(pid: AtomicReference[Pid]): CommandIO[State] =
     new Command[State, Spawn, Pid] {
 
-      override def vars(i: Spawn): List[Var[_]] =
-        Nil
-
       override def gen(s: State): Option[Gen[Spawn]] =
         Some(Gen.constant(Spawn()))
 
@@ -152,9 +149,6 @@ object Registry {
           def apply(x: Pid): Pid =
             Pid(x.value + 1)
         }))
-
-      def require(state: State, input: Spawn): Boolean =
-        true
 
       def update(s: State, i: Spawn, o: Var[Pid]): State =
         s.copy(pids = s.pids + o)
@@ -191,7 +185,7 @@ object Registry {
             Right(())
         }
 
-      def require(state: State, input: Register): Boolean =
+      override def require(state: State, input: Register): Boolean =
         !state.regs.contains(input.name) && !state.regs.exists(x => x._2 == input.value)
 
       def update(s: State, i: Register, o: Var[Unit]): State =
@@ -203,9 +197,6 @@ object Registry {
 
   def unregisterCommand(procTable: concurrent.Map[Name, Pid]): CommandIO[State] =
     new Command[State, Unregister, Unit] {
-
-      override def vars(i: Unregister): List[Var[_]] =
-        Nil
 
       override def gen(s: State): Option[Gen[Unregister]] =
         s.regs.keys.toList match {
@@ -223,7 +214,7 @@ object Registry {
             Right(())
         }
 
-      def require(state: State, input: Unregister): Boolean =
+      override def require(state: State, input: Unregister): Boolean =
         state.regs.contains(input.name)
 
       def update(s: State, i: Unregister, o: Var[Unit]): State =
@@ -248,9 +239,6 @@ object Accumulator {
   def command(name: Int, expected: Int, ref: AtomicReference[Int]): CommandIO[Int] =
     new Command[Int, Register, Boolean] {
 
-      override def vars(i: Register): List[Var[_]] =
-        Nil
-
       override def gen(s: Int): Option[Gen[Register]] =
         Some(Gen.constant(Register(name)))
 
@@ -261,9 +249,6 @@ object Accumulator {
               if (x + 1 == s.name) s.name else x
           }) == s.name
         )
-
-      def require(state: Int, input: Register): Boolean =
-        true
 
       def update(s: Int, i: Register, o: Var[Boolean]): Int =
         if (s + 1 == i.name) i.name else s
@@ -284,9 +269,6 @@ object GetAndSet {
   def command(ref: AtomicReference[String], goodBoy: Boolean): CommandIO[String] =
     new Command[String, String, String] {
 
-      override def vars(i: String): List[Var[_]] =
-        Nil
-
       override def gen(s: String): Option[Gen[String]] =
         Some(Gen.element1("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"))
 
@@ -306,9 +288,6 @@ object GetAndSet {
           Right(s0)
         }
       }
-
-      def require(state: String, input: String): Boolean =
-        true
 
       def update(s: String, i: String, o: Var[String]): String =
         if (s < i) i else s


### PR DESCRIPTION
/cc @Kevin-Lee

Both these are slightly less likely to be required, but might cause confusion when first implementing Command. We might also want to make ensure optional in a slightly
different way.  