### PR TITLE
Move log labels to journal

### DIFF
--- a/core/src/main/scala/hedgehog/Property.scala
+++ b/core/src/main/scala/hedgehog/Property.scala
@@ -16,6 +16,9 @@ trait PropertyTOps extends PropertyTReporting {
   def writeLog(log: Log): PropertyT[Unit] =
     hoist((Journal.empty.log(log), ()))
 
+  def cover(label: Label[Cover]): PropertyT[Unit] =
+    hoist((Journal(Nil, Coverage(Map(label.name -> label))), ()))
+
   def info(log: String): PropertyT[Unit] =
     writeLog(Info(log))
 

--- a/core/src/main/scala/hedgehog/core/Coverage.scala
+++ b/core/src/main/scala/hedgehog/core/Coverage.scala
@@ -89,21 +89,10 @@ object Coverage {
   def empty[A]: Coverage[A] =
     Coverage(Map.empty[LabelName, Label[A]])
 
-  def fromLogs(logs: List[Log]): Coverage[CoverCount] =
-    fromLabels(logs.flatMap {
-      case Log.LabelX(l) =>
-        List(l)
-      case _ =>
-        Nil
-    })
-
-  def fromLabels(labels: List[Label[Cover]]): Coverage[CoverCount] = {
-    val cv = labels.map(l => Coverage(Map(l.name -> l)))
-      .foldLeft(Coverage.empty[Cover])(union(_, _)(_ ++ _))
+  def count(cv: Coverage[Cover]): Coverage[CoverCount] =
     cv.copy(labels = cv.labels.map { case (k, l) =>
       k -> l.copy(annotation = CoverCount.fromCover(l.annotation))
     })
-  }
 
   def union[A](a: Coverage[A], b: Coverage[A])(append: (A, A) => A): Coverage[A] =
     Coverage(b.labels.toList.foldLeft(a.labels) { case (m, (k, v)) =>

--- a/runner/src/main/scala/hedgehog/runner/Properties.scala
+++ b/runner/src/main/scala/hedgehog/runner/Properties.scala
@@ -61,7 +61,7 @@ object Test {
     report.status match {
       case Failed(shrinks, log) =>
         render(false, s"Falsified after ${report.tests.value} passed tests",
-          log.flatMap(renderLog) ++ renderCoverage(report.coverage, report.tests))
+          log.map(renderLog) ++ renderCoverage(report.coverage, report.tests))
       case GaveUp =>
         render(false, s"Gave up after only ${report.tests.value} passed test. " +
           s"${report.discards.value} were discarded", Nil)
@@ -70,19 +70,16 @@ object Test {
     }
   }
 
-  def renderLog(log: Log): List[String] =
+  def renderLog(log: Log): String =
     log match {
       case ForAll(name, value) =>
-        List(s"${name.value}: $value")
+        s"${name.value}: $value"
       case Info(value) =>
-        List(value)
+        value
       case Error(e) =>
         val sw = new java.io.StringWriter()
         e.printStackTrace(new java.io.PrintWriter(sw))
-        List(sw.toString)
-      case Log.LabelX(_) =>
-        // FIXME I think this is a smell that labels don't belong in log
-        Nil
+        sw.toString
     }
 
   def renderCoverage(coverage: Coverage[CoverCount], tests: SuccessCount): List[String] = {


### PR DESCRIPTION
Not sure about this, want to find out why it was undone in https://github.com/hedgehogqa/haskell-hedgehog/pull/262