### PR TITLE
Fix a tiny typo on the turnstile example

### DIFF
--- a/example/src/main/scala/hedgehog/examples/state/TurnstileTest.scala
+++ b/example/src/main/scala/hedgehog/examples/state/TurnstileTest.scala
@@ -10,6 +10,25 @@ import hedgehog.state._
 import scala.concurrent.ExecutionContext.Implicits._
 
 /**
+ * An effectful turnstile
+ *
+ *             Coin
+ *    Push    +-------------+
+ *  +-----+   |             |     +-----+
+ *  |     |   |             v     v     |
+ *  |   +-+---+--+       +--+-----+-+   |
+ *  |   |        |       |          |   |
+ *  |   | Locked |       | Unlocked |   |
+ *  |   |        |       |          |   |
+ *  |   +-+---+--+       +--+-----+-+   |
+ *  |     ^   ^             |     |     |
+ *  +-----+   |             |     +-----+
+ *            +-------------+      Coin
+ *                      Push
+ *
+ * - States: Locked/Unlocked (represented by the boxes)
+ * - Transitions: Coin/Push (represented by the arrows)
+ *
  * https://teh.id.au/posts/2017/07/15/state-machine-testing/index.html
  */
 object TurnstileTest extends Properties {

--- a/example/src/main/scala/hedgehog/examples/state/TurnstileTest.scala
+++ b/example/src/main/scala/hedgehog/examples/state/TurnstileTest.scala
@@ -157,7 +157,7 @@ object TurnstileTest extends Properties {
   object State {
 
     def default: State =
-      State(TurnstileState.inititalState)
+      State(TurnstileState.initialState)
   }
 }
 
@@ -168,7 +168,7 @@ object TurnstileState {
   case object Locked extends TurnstileState
   case object Unlocked extends TurnstileState
 
-  def inititalState: TurnstileState =
+  def initialState: TurnstileState =
     Locked
 }
 
@@ -177,7 +177,7 @@ case class Turnstile(
   ) {
 
   def reset(): Unit = {
-    state.set(TurnstileState.inititalState)
+    state.set(TurnstileState.initialState)
   }
 
   def insertCoin(): Unit = {
@@ -203,5 +203,5 @@ case class Turnstile(
 object Turnstile {
 
   def create: Turnstile =
-    Turnstile(new AtomicReference(TurnstileState.inititalState))
+    Turnstile(new AtomicReference(TurnstileState.initialState))
 }


### PR DESCRIPTION
Nothing groundbreaking on`examples/state/TurnstileTest.scala`:

* from `inititalState` to `initialState`
* I also added a questionable asciiart diagram from the related blogpost