### PR TITLE
Frequency weights

### DIFF
--- a/core/src/main/scala/hedgehog/Gen.scala
+++ b/core/src/main/scala/hedgehog/Gen.scala
@@ -127,7 +127,7 @@ trait GenTOps extends MonadGenOps[Gen] {
        else
          xs match {
            case Nil =>
-             Gen.discard
+             sys.error("Invariant: frequency hits an impossible code path")
            case h :: t =>
              pick(n - x._1, h, t)
          }
@@ -136,11 +136,14 @@ trait GenTOps extends MonadGenOps[Gen] {
        case (weight, gen) => math.max(weight, 0) -> gen
      }
      val total = nonNegative.map(_._1.toLong).sum
-     for {
-       // Ensure n is positive to avoid picking any generator if all weights are non-positive.
-       n <- long(Range.constant(1, math.max(1, total)))
-       x <- pick(n, nonNegative.head, nonNegative.tail)
-     } yield x
+     if (total > 0) {
+       for {
+         n <- long(Range.constant(1, total))
+         x <- pick(n, nonNegative.head, nonNegative.tail)
+       } yield x
+     } else {
+       sys.error("frequency: no positive weights were given so no value can be generated")
+     }
    }
 
   /**

--- a/core/src/main/scala/hedgehog/Gen.scala
+++ b/core/src/main/scala/hedgehog/Gen.scala
@@ -131,19 +131,15 @@ trait GenTOps extends MonadGenOps[Gen] {
            case h :: t =>
              pick(n - x._1, h, t)
          }
-     // Treat negative weights as zero.
-     val nonNegative = (a :: l).map {
-       case (weight, gen) => math.max(weight, 0) -> gen
+     val hasNonPositive = (a :: l).exists {
+       case (weight, _) => weight <= 0
      }
-     val total = nonNegative.map(_._1.toLong).sum
-     if (total > 0) {
-       for {
-         n <- long(Range.constant(1, total))
-         x <- pick(n, nonNegative.head, nonNegative.tail)
-       } yield x
-     } else {
-       sys.error("frequency: no positive weights were given so no value can be generated")
-     }
+     if (hasNonPositive) sys.error("Invariant: a non-positive weight was given")
+     val total = (a :: l).map(_._1.toLong).sum
+     for {
+       n <- long(Range.constant(1, total))
+       x <- pick(n, a, l)
+     } yield x
    }
 
   /**

--- a/core/src/main/scala/hedgehog/Gen.scala
+++ b/core/src/main/scala/hedgehog/Gen.scala
@@ -137,8 +137,9 @@ trait GenTOps extends MonadGenOps[Gen] {
      }
      val total = nonNegative.map(_._1.toLong).sum
      for {
-       n <- long(Range.constant(1, total))
-       x <- pick(n, a, l)
+       // Ensure n is positive to avoid picking any generator if all weights are non-positive.
+       n <- long(Range.constant(1, math.max(1, total)))
+       x <- pick(n, nonNegative.head, nonNegative.tail)
      } yield x
    }
 

--- a/core/src/main/scala/hedgehog/Gen.scala
+++ b/core/src/main/scala/hedgehog/Gen.scala
@@ -121,7 +121,7 @@ trait GenTOps extends MonadGenOps[Gen] {
     */
    def frequency[A](a: (Int, GenT[A]), l: List[(Int, GenT[A])]): GenT[A] = {
      @annotation.tailrec
-     def pick(n: Int, x: (Int, GenT[A]), xs: List[(Int, GenT[A])]): GenT[A] =
+     def pick(n: Long, x: (Int, GenT[A]), xs: List[(Int, GenT[A])]): GenT[A] =
        if (n <= x._1)
          x._2
        else
@@ -131,9 +131,9 @@ trait GenTOps extends MonadGenOps[Gen] {
            case h :: t =>
              pick(n - x._1, h, t)
          }
-     val total = (a :: l).map(_._1).sum
+     val total = (a :: l).map(_._1.toLong).sum
      for {
-       n <- int(Range.constant(1, total))
+       n <- long(Range.constant(1, total))
        x <- pick(n, a, l)
      } yield x
    }

--- a/core/src/main/scala/hedgehog/Gen.scala
+++ b/core/src/main/scala/hedgehog/Gen.scala
@@ -127,11 +127,15 @@ trait GenTOps extends MonadGenOps[Gen] {
        else
          xs match {
            case Nil =>
-             sys.error("Invariant: frequency hits an impossible code path")
+             Gen.discard
            case h :: t =>
              pick(n - x._1, h, t)
          }
-     val total = (a :: l).map(_._1.toLong).sum
+     // Treat negative weights as zero.
+     val nonNegative = (a :: l).map {
+       case (weight, gen) => math.max(weight, 0) -> gen
+     }
+     val total = nonNegative.map(_._1.toLong).sum
      for {
        n <- long(Range.constant(1, total))
        x <- pick(n, a, l)

--- a/test/src/test/scala/hedgehog/GenTest.scala
+++ b/test/src/test/scala/hedgehog/GenTest.scala
@@ -12,6 +12,7 @@ object GenTest extends Properties {
     , example("frequency is random", testFrequency)
     , property("frequency handles large weights", testFrequencyLargeWeights)
         .config(c => c.copy(testLimit = SuccessCount(100000)))
+    , property("frequency ignores non-positive weights", testFrequencyNonPositiveWeights)
     , example("fromSome some", testFromSomeSome)
     , example("fromSome none", testFromSomeNone)
     , example("applicative", testApplicative)
@@ -42,6 +43,17 @@ object GenTest extends Properties {
         .cover(CoverPercentage(0.50), LabelName("First generator"), Cover.Boolean2Cover)
         .cover(CoverPercentage(0.50), LabelName("Second generator"), b => Cover.Boolean2Cover(!b))
     } yield Result.success
+  }
+
+  def testFrequencyNonPositiveWeights: Property = {
+    for {
+      nonPositiveWeight <- Gen.int(Range.constant(0, Int.MinValue)).forAll
+      positiveWeight <- Gen.int(Range.constant(1, Int.MaxValue)).forAll
+      trueOrFalse <- Gen.frequency1(
+        (nonPositiveWeight, Gen.constant(false)),
+        (positiveWeight, Gen.constant(true))
+      ).forAll
+    } yield trueOrFalse ==== true
   }
 
   def testFromSomeSome: Result = {

--- a/test/src/test/scala/hedgehog/GenTest.scala
+++ b/test/src/test/scala/hedgehog/GenTest.scala
@@ -10,8 +10,7 @@ object GenTest extends Properties {
       property("long generates correctly", testLong)
     , property("withFilter filters values", testWithFilter)
     , example("frequency is random", testFrequency)
-    , property("frequency handles large weights", testFrequencyLargeWeights)
-        .config(c => c.copy(testLimit = SuccessCount(100000)))
+    , property("frequency handles large weights", testFrequencyLargeWeights).withTests(100000)
     , property("frequency ignores non-positive weights", testFrequencyNonPositiveWeights)
     , property("frequency discards if no positive weights", testFrequencyNoPositiveWeights)
     , example("fromSome some", testFromSomeSome)
@@ -41,8 +40,8 @@ object GenTest extends Properties {
         (Int.MaxValue, Gen.constant(true)),
         (Int.MaxValue, Gen.constant(false))
       ).forAll
-        .cover(CoverPercentage(0.50), LabelName("First generator"), Cover.Boolean2Cover)
-        .cover(CoverPercentage(0.50), LabelName("Second generator"), b => Cover.Boolean2Cover(!b))
+        .cover(CoverPercentage(45), LabelName("First generator"), Cover.Boolean2Cover)
+        .cover(CoverPercentage(45), LabelName("Second generator"), b => Cover.Boolean2Cover(!b))
     } yield Result.success
   }
 


### PR DESCRIPTION
This addresses both problems with the weights in `Gen.frequency`:

1. Non-positive weights cause a `RuntimeException`
  - The solution maps all the negative weights to `0` and then uses the terminal case to discard the generator if all weights are non-positive.
  - Extra care is needed here to make sure that the `n` is also positive in the case where the `total` of all weights is `0`.
2. Large positive weights cause an integer overflow in the `total` meaning that it always picks the first generator (assuming the weight is positive).
  - The fix uses a `Long` to store the `total`. This is safe even if there are `Int.MaxValue` generators each with a weight of `Int.MaxValue`.

Fixes #99 
