### PR TITLE
Add better handling for fractional percentage cover

### DIFF
--- a/core/src/main/scala/hedgehog/core/Coverage.scala
+++ b/core/src/main/scala/hedgehog/core/Coverage.scala
@@ -33,7 +33,7 @@ case class CoverCount(toInt: Int) {
     CoverCount(toInt + o.toInt)
 
   def percentage(tests: SuccessCount): CoverPercentage =
-    CoverPercentage(((toInt.toDouble / tests.value.toDouble) * 100 * 10).round / 10)
+    CoverPercentage(((toInt.toDouble / tests.value.toDouble) * 100 * 100).ceil / 100)
 }
 
 object CoverCount {

--- a/test/src/test/scala/hedgehog/CoverageTest.scala
+++ b/test/src/test/scala/hedgehog/CoverageTest.scala
@@ -9,6 +9,7 @@ object CoverageTest extends Properties {
     List(
       example("test cover passes", testCoverPass)
     , example("test cover fails", testCoverFail)
+    , example("test cover fractional percentages", testCoverFractionalPercentages)
     )
 
   def testCoverPass: Result = {
@@ -43,6 +44,30 @@ object CoverageTest extends Properties {
         case s =>
           Result.failure.log(s.toString)
       }
+    ))
+  }
+
+  // We generate a random number between 1 and 10,000.
+  // The expected probability of getting 80 or lower is 80 / 10,000 or 1 / 125.
+  // The expected probability of getting 80 or higher is 9,920 / 10,000 or 124 / 125.
+  // If we run the test 10,000 times then we would expect:
+  // <= 80, 80 times, and > 80, 9920 times.
+  // Calculating the binomial proportion confidence intervals for 99.9999999999999% confidence:
+  // None: 0.0063 to 0.0099
+  // Some: 0.9901 to 0.9937
+  // See https://statpages.info/confint.html#Binomial
+  def testCoverFractionalPercentages: Result = {
+    val g =
+      for {
+        _ <- Gen.int(Range.constant(1, 10000)).forAll
+          .cover(0.0063, "<= 80", _ <= 80)
+          .cover(0.9901, "> 80", _ > 80)
+      } yield Result.success
+
+    val r = Property.checkRandom(PropertyConfig.default.copy(testLimit = 10000), g)
+    Result.all(List(
+      r.coverage.labels.keys.toList.sortBy(_.render) ==== List(LabelName("<= 80"), LabelName("> 80"))
+      , r.status ==== Status.ok
     ))
   }
 }


### PR DESCRIPTION
I had a generator that I was testing which was generating values within a confidence interval of 1.03% and 2.8% with 10,000 samples and a confidence of 99.99999%.

This was failing about 1/3rd of the time.

It turns out that if the actual percentage was < 1.95% then this would be rounded down to 1.0% which is less than 1.03% and the test would fail.

If anything we need to round up rather than down. I also made it accurate to 2 decimal places instead of 1.