### PR TITLE
Future result

### DIFF
--- a/core/src/main/scala/hedgehog/Property.scala
+++ b/core/src/main/scala/hedgehog/Property.scala
@@ -1,6 +1,7 @@
 package hedgehog
 
 import hedgehog.core._
+import hedgehog.predef.Monad
 
 trait PropertyTOps extends PropertyTReporting {
 
@@ -36,6 +37,9 @@ trait PropertyTOps extends PropertyTReporting {
 
   def check(config: PropertyConfig, p: PropertyT[Result], seed: Seed): Report =
     propertyT.report(config, None, seed, p)
+
+  def checkF[F[_]: Monad](config: PropertyConfig, p: PropertyT[F[Result]], seed: Seed): F[Report] =
+    propertyT.reportF(config, None, seed, p)
 
   def checkRandom(config: PropertyConfig, p: PropertyT[Result]): Report =
     // FIX: predef MonadIO

--- a/core/src/main/scala/hedgehog/core/GenT.scala
+++ b/core/src/main/scala/hedgehog/core/GenT.scala
@@ -153,8 +153,9 @@ abstract class GenImplicits2 extends GenImplicits1 {
 
 object GenT extends GenImplicits2 {
 
+  // TODO: Is bind stack-safe?
   implicit def GenMonad: Monad[GenT] =
-    new Monad[GenT] {
+    new Monad[GenT] with StackSafeMonad[GenT] {
 
      override def map[A, B](fa: GenT[A])(f: A => B): GenT[B] =
        fa.map(f)

--- a/core/src/main/scala/hedgehog/core/GenT.scala
+++ b/core/src/main/scala/hedgehog/core/GenT.scala
@@ -143,6 +143,7 @@ abstract class GenImplicits2 extends GenImplicits1 {
       override def ap[A, B](fa: => GenT[A])(f: => GenT[A => B]): GenT[B] =
         GenT((size, seed) => {
           val f2 = f.run(size, seed)
+          // FIXME: This is not stack safe.
           val fa2 = fa.run(size, f2.value._1)
           Applicative.zip(fa2, f2).map { case ((seed2, oa), (_, o)) =>
             (seed2, o.flatMap(y => oa.map(y(_))))
@@ -153,9 +154,8 @@ abstract class GenImplicits2 extends GenImplicits1 {
 
 object GenT extends GenImplicits2 {
 
-  // TODO: Is bind stack-safe?
   implicit def GenMonad: Monad[GenT] =
-    new Monad[GenT] with StackSafeMonad[GenT] {
+    new Monad[GenT] {
 
      override def map[A, B](fa: GenT[A])(f: A => B): GenT[B] =
        fa.map(f)
@@ -168,5 +168,12 @@ object GenT extends GenImplicits2 {
 
       override def bind[A, B](fa: GenT[A])(f: A => GenT[B]): GenT[B] =
         fa.flatMap(f)
+
+      // FIXME: This is not stack safe.
+      override def tailRecM[A, B](a: A)(f: A => GenT[Either[A, B]]): GenT[B] =
+        bind(f(a)) {
+          case Left(value) => tailRecM(value)(f)
+          case Right(value) => point(value)
+        }
     }
 }

--- a/core/src/main/scala/hedgehog/core/PropertyT.scala
+++ b/core/src/main/scala/hedgehog/core/PropertyT.scala
@@ -15,8 +15,11 @@ object Name {
 }
 
 sealed trait Log
+
 case class ForAll(name: Name, value: String) extends Log
+
 case class Info(value: String) extends Log
+
 case class Error(value: Exception) extends Log
 
 object Log {
@@ -27,9 +30,9 @@ object Log {
 
 /** A record containing the details of a test run. */
 case class Journal(
-    logs: List[Log]
-  , coverage: Coverage[Cover]
-  ) {
+                    logs: List[Log]
+                    , coverage: Coverage[Cover]
+                  ) {
 
   def ++(o: Journal): Journal =
     Journal(logs ++ o.logs, Coverage.union(coverage, o.coverage)(_ ++ _))
@@ -45,10 +48,10 @@ object Journal {
 }
 
 case class PropertyConfig(
-    testLimit: SuccessCount
-  , discardLimit: DiscardCount
-  , shrinkLimit: ShrinkLimit
-  )
+                           testLimit: SuccessCount
+                           , discardLimit: DiscardCount
+                           , shrinkLimit: ShrinkLimit
+                         )
 
 object PropertyConfig {
 
@@ -57,8 +60,8 @@ object PropertyConfig {
 }
 
 case class PropertyT[A](
-    run: GenT[(Journal, Option[A])]
-  ) {
+                         run: GenT[(Journal, Option[A])]
+                       ) {
 
   def map[B](f: A => B): PropertyT[B] =
     copy(run = run.map(x =>
@@ -75,7 +78,7 @@ case class PropertyT[A](
   def flatMap[B](f: A => PropertyT[B]): PropertyT[B] =
     copy(run = run.flatMap(x =>
       x._2.fold(
-       GenT.GenApplicative.point((x._1, Option.empty[B]))
+        GenT.GenApplicative.point((x._1, Option.empty[B]))
       )(a =>
         try {
           f(a).run.map(y => (x._1 ++ y._1, y._2))
@@ -121,12 +124,15 @@ object PropertyT {
     new Monad[PropertyT] with StackSafeMonad[PropertyT] {
       override def map[A, B](fa: PropertyT[A])(f: A => B): PropertyT[B] =
         fa.map(f)
+
       override def point[A](a: => A): PropertyT[A] =
         propertyT.hoist((Journal.empty, a))
+
       override def ap[A, B](fa: => PropertyT[A])(f: => PropertyT[A => B]): PropertyT[B] =
         PropertyT(Applicative.zip(fa.run, f.run)
           .map { case ((l1, oa), (l2, oab)) => (l2 ++ l1, oab.flatMap(y => oa.map(y(_)))) }
         )
+
       override def bind[A, B](fa: PropertyT[A])(f: A => PropertyT[B]): PropertyT[B] =
         fa.flatMap(f)
     }
@@ -134,67 +140,86 @@ object PropertyT {
 
 trait PropertyTReporting {
 
-  @annotation.tailrec
-  final def takeSmallest(n: ShrinkCount, slimit: ShrinkLimit, t: Tree[Option[(List[Log], Option[Result])]]): Status =
-    t.value match {
-      case None =>
-        Status.gaveUp
+  final def takeSmallest(n: ShrinkCount, slimit: ShrinkLimit, t: Tree[Option[(List[Log], Option[Result])]]): Status = {
+    // TODO: Can we cast this instead?
+    val t2 = t.map(_.map { case (l, r) => (l, r.map[Id[Result]](identity)) })
+    takeSmallestF(n, slimit, t2)
+  }
 
-      case Some((w, r)) =>
+  final def takeSmallestF[F[_]](n: ShrinkCount, slimit: ShrinkLimit, t: Tree[Option[(List[Log], Option[F[Result]])]])(implicit M: Monad[F]): F[Status] = {
+    type TreeF = Tree[Option[(List[Log], Option[F[Result]])]]
+    type Arguments = (ShrinkCount, ShrinkLimit, TreeF)
+    val zero: Arguments = (n, slimit, t)
+    M.tailRecM(zero) { case (n, slimit, t) =>
+      def smallestChild(w: List[Log], r: Option[Result]): F[Either[Arguments, Status]] = {
         if (r.forall(!_.success)) {
           if (n.value >= slimit.value) {
-            Status.failed(n, w ++ r.map(_.logs).getOrElse(Nil))
+            M.point(Right(Status.failed(n, w ++ r.map(_.logs).getOrElse(Nil))))
           } else {
-            findMap(t.children.value)(m =>
+            val x: F[Option[TreeF]] = findMapF(t.children.value) { m =>
               m.value match {
                 case Some((_, None)) =>
-                  some(m)
-                case Some((_, Some(r2))) =>
+                  M.point(some(m))
+                case Some((_, Some(f2))) => M.map(f2) { r2 =>
                   if (!r2.success)
                     some(m)
                   else
                     Option.empty
+                }
                 case None =>
-                  Option.empty
+                  M.point(Option.empty)
               }
-            ) match {
+            }
+            M.map(x) {
               case Some(m) =>
-                takeSmallest(n.inc, slimit, m)
+                Left((n.inc, slimit, m))
               case None =>
-                Status.failed(n, w ++ r.map(_.logs).getOrElse(Nil))
+                Right(Status.failed(n, w ++ r.map(_.logs).getOrElse(Nil)))
             }
           }
         } else {
-          Status.ok
+          M.point(Right(Status.ok))
         }
-    }
+      }
 
-  def report(config: PropertyConfig, size0: Option[Size], seed0: Seed, p: PropertyT[Result]): Report = {
-    reportF(config, size0, seed0, p.map[Id[Result]](identity))
+      t.value match {
+        case None =>
+          M.point(Right(Status.gaveUp))
+        case Some((w, Some(f))) =>
+          M.bind(f) { r =>
+            smallestChild(w, Some(r))
+          }
+        case Some((w, None)) =>
+          smallestChild(w, None)
+      }
+    }
   }
 
-  def reportF[F[_]](config: PropertyConfig, size0: Option[Size], seed0: Seed, p: PropertyT[F[Result]])(implicit m: Monad[F]): F[Report] = {
+  def report(config: PropertyConfig, size0: Option[Size], seed0: Seed, p: PropertyT[Result]): Report =
+  // TODO: Can we cast this instead?
+    reportF(config, size0, seed0, p.map(identity[Id[Result]]))
+
+  def reportF[F[_]](config: PropertyConfig, size0: Option[Size], seed0: Seed, p: PropertyT[F[Result]])(implicit M: Monad[F]): F[Report] = {
     // Increase the size proportionally to the number of tests to ensure better coverage of the desired range
     val sizeInc = Size(Math.max(1, Size.max / config.testLimit.value))
     // Start the size at whatever remainder we have to ensure we run with "max" at least once
     val sizeInit = Size(Size.max % Math.min(config.testLimit.value, Size.max)).incBy(sizeInc)
     type Arguments = (SuccessCount, DiscardCount, Size, Seed, Coverage[CoverCount])
     val zero: Arguments = (SuccessCount(0), DiscardCount(0), size0.getOrElse(sizeInit), seed0, Coverage.empty)
-    m.tailRecM(zero) { case (successes, discards, size, seed, coverage) =>
+    M.tailRecM(zero) { case (successes, discards, size, seed, coverage) =>
       if (size.value > Size.max)
-        m.point(Left((successes, discards, sizeInit, seed, coverage)))
+        M.point(Left((successes, discards, sizeInit, seed, coverage)))
       else if (successes.value >= config.testLimit.value)
       // we've hit the test limit
       Coverage.split(coverage, successes) match {
         case (_, Nil) =>
-          m.point(Right(Report(successes, discards, coverage, OK)))
+          M.point(Right(Report(successes, discards, coverage, OK)))
         case _ =>
-          m.point(Right(Report(successes, discards, coverage, Status.failed(ShrinkCount(0), List("Insufficient coverage.")))))
+          M.point(Right(Report(successes, discards, coverage, Status.failed(ShrinkCount(0), List("Insufficient coverage.")))))
       }
       else if (discards.value >= config.discardLimit.value)
-        m.point(Right(Report(successes, discards, coverage, GaveUp)))
+        M.point(Right(Report(successes, discards, coverage, GaveUp)))
       else {
-        // Tree[(Seed, Option[(Journal, Option[F[Result]])])]
         val x =
           try {
             p.run.run(size, seed)
@@ -202,23 +227,26 @@ trait PropertyTReporting {
             case e: Exception =>
               Property.error(e).run.run(size, seed)
           }
-        // Tree[Option[(List[Log], Option[F[Result]])]]
-        //        val t = x.map(_._2.map { case (l, r) => (l.logs, r) })
+
+        def reportSmallest: F[Either[Arguments, Report]] = {
+          val t = x.map(_._2.map { case (l, r) => (l.logs, r) })
+          val smallestF = takeSmallestF(ShrinkCount(0), config.shrinkLimit, t)
+          M.map(smallestF) { smallest =>
+            Right(Report(successes, discards, coverage, smallest))
+          }
+        }
+
         x.value._2 match {
           case None =>
-            m.point(Left((successes, discards.inc, size.incBy(sizeInc), x.value._1, coverage)))
-
+            M.point(Left((successes, discards.inc, size.incBy(sizeInc), x.value._1, coverage)))
           case Some((_, None)) =>
-            val t = x.map(_._2.map { case (l, _) => (l.logs, Option.empty[Result]) })
-            m.point(Right(Report(successes, discards, coverage, takeSmallest(ShrinkCount(0), config.shrinkLimit, t))))
-
-          case Some((j, Some(fr))) => m.map(fr) { r =>
+            reportSmallest
+          case Some((j, Some(f))) => M.bind(f) { r =>
             if (!r.success) {
-              val t = x.map(_._2.map { case (l, _) => (l.logs, Option(r)) })
-              Right(Report(successes, discards, coverage, takeSmallest(ShrinkCount(0), config.shrinkLimit, t)))
+              reportSmallest
             } else
-              Left((successes.inc, discards, size.incBy(sizeInc), x.value._1,
-                Coverage.union(Coverage.count(j.coverage), coverage)(_ + _)))
+              M.point(Left((successes.inc, discards, size.incBy(sizeInc), x.value._1,
+                Coverage.union(Coverage.count(j.coverage), coverage)(_ + _))))
           }
         }
       }
@@ -228,11 +256,11 @@ trait PropertyTReporting {
   def recheck(config: PropertyConfig, size: Size, seed: Seed)(p: PropertyT[Result]): Report =
     report(config.copy(testLimit = SuccessCount(1)), Some(size), seed, p)
 
-  def recheckF[F[_]: Monad](config: PropertyConfig, size: Size, seed: Seed)(p: PropertyT[F[Result]]): F[Report] =
+  def recheckF[F[_] : Monad](config: PropertyConfig, size: Size, seed: Seed)(p: PropertyT[F[Result]]): F[Report] =
     reportF(config.copy(testLimit = SuccessCount(1)), Some(size), seed, p)
 }
 
-/**********************************************************************/
+/** ********************************************************************/
 // Reporting
 
 /** The numbers of times a property was able to shrink after a failing test. */
@@ -272,8 +300,11 @@ case class DiscardCount(value: Int) {
  * number of shrinks, and the execution log.
  */
 sealed trait Status
+
 case class Failed(shrinks: ShrinkCount, log: List[Log]) extends Status
+
 case object GaveUp extends Status
+
 case object OK extends Status
 
 object Status {

--- a/core/src/main/scala/hedgehog/core/PropertyT.scala
+++ b/core/src/main/scala/hedgehog/core/PropertyT.scala
@@ -170,7 +170,7 @@ trait PropertyTReporting {
     }
 
   def report(config: PropertyConfig, size0: Option[Size], seed0: Seed, p: PropertyT[Result]): Report = {
-    reportF(config, size0, seed0, p.map(Identity(_))).value
+    reportF(config, size0, seed0, p.map[Id[Result]](identity))
   }
 
   def reportF[F[_]](config: PropertyConfig, size0: Option[Size], seed0: Seed, p: PropertyT[F[Result]])(implicit m: Monad[F]): F[Report] = {

--- a/core/src/main/scala/hedgehog/core/PropertyT.scala
+++ b/core/src/main/scala/hedgehog/core/PropertyT.scala
@@ -119,9 +119,8 @@ case class PropertyT[A](
 
 object PropertyT {
 
-  // TODO: Is bind stack-safe?
   implicit def PropertyMonad: Monad[PropertyT] =
-    new Monad[PropertyT] with StackSafeMonad[PropertyT] {
+    new Monad[PropertyT] {
       override def map[A, B](fa: PropertyT[A])(f: A => B): PropertyT[B] =
         fa.map(f)
 

--- a/core/src/main/scala/hedgehog/core/PropertyT.scala
+++ b/core/src/main/scala/hedgehog/core/PropertyT.scala
@@ -135,6 +135,13 @@ object PropertyT {
 
       override def bind[A, B](fa: PropertyT[A])(f: A => PropertyT[B]): PropertyT[B] =
         fa.flatMap(f)
+
+      // FIXME: This is not stack safe.
+      override def tailRecM[A, B](a: A)(f: A => PropertyT[Either[A, B]]): PropertyT[B] =
+        bind(f(a)) {
+          case Left(value) => tailRecM(value)(f)
+          case Right(value) => point(value)
+        }
     }
 }
 

--- a/core/src/main/scala/hedgehog/core/Tree.scala
+++ b/core/src/main/scala/hedgehog/core/Tree.scala
@@ -56,7 +56,7 @@ abstract class TreeImplicits2 extends TreeImplicits1 {
 object Tree extends TreeImplicits2 {
 
   implicit def TreeMonad: Monad[Tree] =
-    new Monad[Tree] with StackSafeMonad[Tree] {
+    new Monad[Tree] {
       override def map[A, B](fa: Tree[A])(f: A => B): Tree[B] =
         fa.map(f)
       override def point[A](a: => A): Tree[A] =

--- a/core/src/main/scala/hedgehog/core/Tree.scala
+++ b/core/src/main/scala/hedgehog/core/Tree.scala
@@ -55,8 +55,9 @@ abstract class TreeImplicits2 extends TreeImplicits1 {
 
 object Tree extends TreeImplicits2 {
 
+  // TODO: Is bind stack-safe?
   implicit def TreeMonad: Monad[Tree] =
-    new Monad[Tree] {
+    new Monad[Tree] with StackSafeMonad[Tree] {
       override def map[A, B](fa: Tree[A])(f: A => B): Tree[B] =
         fa.map(f)
       override def point[A](a: => A): Tree[A] =

--- a/core/src/main/scala/hedgehog/core/Tree.scala
+++ b/core/src/main/scala/hedgehog/core/Tree.scala
@@ -55,7 +55,6 @@ abstract class TreeImplicits2 extends TreeImplicits1 {
 
 object Tree extends TreeImplicits2 {
 
-  // TODO: Is bind stack-safe?
   implicit def TreeMonad: Monad[Tree] =
     new Monad[Tree] with StackSafeMonad[Tree] {
       override def map[A, B](fa: Tree[A])(f: A => B): Tree[B] =
@@ -70,6 +69,12 @@ object Tree extends TreeImplicits2 {
           y.value, fa.children.flatMap(x => y.children.map(ys => x.map(_.flatMap(f)) ++ ys))
         )
       }
+      // FIXME: This is not stack safe.
+      override def tailRecM[A, B](a: A)(f: A => Tree[Either[A, B]]): Tree[B] =
+        bind(f(a)) {
+          case Left(value) => tailRecM(value)(f)
+          case Right(value) => point(value)
+        }
     }
 
   def unfoldTree[A, B](f: B => A, g: B => List[B], x: B): Tree[A] =

--- a/core/src/main/scala/hedgehog/predef/Identity.scala
+++ b/core/src/main/scala/hedgehog/predef/Identity.scala
@@ -25,8 +25,6 @@ object Identity {
         a
     }
 
-  // FIXME: Ironically the one that we ought to be able to consider stack-safe for bind is not.
-  //  Why does this have to be call-by-need?
   implicit def IdentityMonad: Monad[Identity] =
     new Monad[Identity] with StackSafeMonad[Identity] {
 
@@ -42,5 +40,12 @@ object Identity {
 
       override def bind[A, B](fa: Identity[A])(f: A => Identity[B]): Identity[B] =
         Identity(f(fa.value).value)
+
+      // FIXME: This is not stack safe.
+      override def tailRecM[A, B](a: A)(f: A => Identity[Either[A, B]]): Identity[B] =
+        bind(f(a)) {
+          case Left(value) => tailRecM(value)(f)
+          case Right(value) => point(value)
+        }
     }
 }

--- a/core/src/main/scala/hedgehog/predef/Identity.scala
+++ b/core/src/main/scala/hedgehog/predef/Identity.scala
@@ -26,7 +26,7 @@ object Identity {
     }
 
   implicit def IdentityMonad: Monad[Identity] =
-    new Monad[Identity] with StackSafeMonad[Identity] {
+    new Monad[Identity] {
 
       // NOTE: It's critical to override the free Applicative version, otherwise we get stack overflows
       override def map[A, B](fa: Identity[A])(f: A => B) =

--- a/core/src/main/scala/hedgehog/predef/Identity.scala
+++ b/core/src/main/scala/hedgehog/predef/Identity.scala
@@ -25,6 +25,8 @@ object Identity {
         a
     }
 
+  // FIXME: Ironically the one that we ought to be able to consider stack-safe for bind is not.
+  //  Why does this have to be call-by-need?
   implicit def IdentityMonad: Monad[Identity] =
     new Monad[Identity] with StackSafeMonad[Identity] {
 

--- a/core/src/main/scala/hedgehog/predef/Identity.scala
+++ b/core/src/main/scala/hedgehog/predef/Identity.scala
@@ -26,7 +26,7 @@ object Identity {
     }
 
   implicit def IdentityMonad: Monad[Identity] =
-    new Monad[Identity] {
+    new Monad[Identity] with StackSafeMonad[Identity] {
 
       // NOTE: It's critical to override the free Applicative version, otherwise we get stack overflows
       override def map[A, B](fa: Identity[A])(f: A => B) =

--- a/core/src/main/scala/hedgehog/predef/State.scala
+++ b/core/src/main/scala/hedgehog/predef/State.scala
@@ -45,7 +45,6 @@ abstract class StateTImplicits2 extends StateTImplicits1 {
 
 object StateT extends StateTImplicits2 {
 
-  // TODO: Is bind stack-safe?
   implicit def StateTMonad[M[_], S](implicit F: Monad[M]): Monad[StateT[M, S, ?]] =
     new Monad[StateT[M, S, ?]] with StackSafeMonad[StateT[M, S, ?]] {
 
@@ -60,6 +59,13 @@ object StateT extends StateTImplicits2 {
 
       override def bind[A, B](fa: StateT[M, S, A])(f: A => StateT[M, S, B]): StateT[M, S, B] =
         fa.flatMap(f)
+
+      // FIXME: This is not stack safe.
+      override def tailRecM[A, B](a: A)(f: A => StateT[M, S, Either[A, B]]): StateT[M, S, B] =
+        bind(f(a)) {
+          case Left(value) => tailRecM(value)(f)
+          case Right(value) => point(value)
+        }
     }
 
 }

--- a/core/src/main/scala/hedgehog/predef/State.scala
+++ b/core/src/main/scala/hedgehog/predef/State.scala
@@ -46,7 +46,7 @@ abstract class StateTImplicits2 extends StateTImplicits1 {
 object StateT extends StateTImplicits2 {
 
   implicit def StateTMonad[M[_], S](implicit F: Monad[M]): Monad[StateT[M, S, ?]] =
-    new Monad[StateT[M, S, ?]] with StackSafeMonad[StateT[M, S, ?]] {
+    new Monad[StateT[M, S, ?]] {
 
       override def map[A, B](fa: StateT[M, S, A])(f: A => B): StateT[M, S, B] =
         fa.map(f)

--- a/core/src/main/scala/hedgehog/predef/State.scala
+++ b/core/src/main/scala/hedgehog/predef/State.scala
@@ -45,8 +45,9 @@ abstract class StateTImplicits2 extends StateTImplicits1 {
 
 object StateT extends StateTImplicits2 {
 
+  // TODO: Is bind stack-safe?
   implicit def StateTMonad[M[_], S](implicit F: Monad[M]): Monad[StateT[M, S, ?]] =
-    new Monad[StateT[M, S, ?]] {
+    new Monad[StateT[M, S, ?]] with StackSafeMonad[StateT[M, S, ?]] {
 
       override def map[A, B](fa: StateT[M, S, A])(f: A => B): StateT[M, S, B] =
         fa.map(f)

--- a/core/src/main/scala/hedgehog/predef/data.scala
+++ b/core/src/main/scala/hedgehog/predef/data.scala
@@ -93,13 +93,3 @@ object Monad {
         }
     }
 }
-
-// FIXME: Get rid of this. It isn't very stack safe in the general case.
-trait StackSafeMonad[F[_]] extends Monad[F] {
-
-  override def tailRecM[A, B](a: A)(f: A => F[Either[A, B]]): F[B] =
-    bind(f(a)) {
-      case Left(value) => tailRecM(value)(f)
-      case Right(value) => point(value)
-    }
-}

--- a/core/src/main/scala/hedgehog/predef/data.scala
+++ b/core/src/main/scala/hedgehog/predef/data.scala
@@ -94,6 +94,7 @@ object Monad {
     }
 }
 
+// FIXME: Get rid of this. It isn't very stack safe in the general case.
 trait StackSafeMonad[F[_]] extends Monad[F] {
 
   override def tailRecM[A, B](a: A)(f: A => F[Either[A, B]]): F[B] =

--- a/core/src/main/scala/hedgehog/predef/data.scala
+++ b/core/src/main/scala/hedgehog/predef/data.scala
@@ -1,5 +1,7 @@
 package hedgehog.predef
 
+import scala.language.higherKinds
+
 trait Functor[F[_]] {
 
   def map[A, B](fa: F[A])(f: A => B): F[B]
@@ -57,6 +59,8 @@ object Applicative {
 trait Monad[F[_]] extends Applicative[F] {
 
   def bind[A, B](fa: F[A])(f: A => F[B]): F[B]
+
+  def tailRecM[A, B](a: A)(f: A => F[Either[A, B]]): F[B]
 }
 
 object Monad {
@@ -75,5 +79,26 @@ object Monad {
 
       override def bind[A, B](fa: Either[L, A])(f: A => Either[L, B]): Either[L, B] =
         fa.rightFlatMap(f)
+
+      @scala.annotation.tailrec
+      override def tailRecM[A, B](a: A)(f: A => Either[L, Either[A, B]]): Either[L, B] =
+        f(a) match {
+          case left @ Left(_) =>
+            left.asInstanceOf[Either[L, B]]
+          case Right(e) =>
+            e match {
+              case Left(b1)         => tailRecM(b1)(f)
+              case right @ Right(_) => right.asInstanceOf[Either[L, B]]
+            }
+        }
+    }
+}
+
+trait StackSafeMonad[F[_]] extends Monad[F] {
+
+  override def tailRecM[A, B](a: A)(f: A => F[Either[A, B]]): F[B] =
+    bind(f(a)) {
+      case Left(value) => tailRecM(value)(f)
+      case Right(value) => point(value)
     }
 }

--- a/core/src/main/scala/hedgehog/predef/package.scala
+++ b/core/src/main/scala/hedgehog/predef/package.scala
@@ -62,7 +62,7 @@ package object predef {
   type Id[A] = A
 
   implicit val IdMonad: Monad[Id] =
-    new Monad[Id] with StackSafeMonad[Id] {
+    new Monad[Id] {
       override def bind[A, B](fa: A)(f: A => B): B = f(fa)
       override def point[A](a: => A): A = a
       override def ap[A, B](fa: => A)(f: => A => B): B = f(fa)

--- a/core/src/main/scala/hedgehog/predef/package.scala
+++ b/core/src/main/scala/hedgehog/predef/package.scala
@@ -1,5 +1,8 @@
 package hedgehog
 
+import scala.annotation.tailrec
+import scala.language.higherKinds
+
 /**
  * We have our own FP predef for 2 reasons.
  *
@@ -27,26 +30,18 @@ package object predef {
   def some[A](a: A): Option[A] =
     Some(a)
 
-  def findMap[A, B](fa: LazyList[A])(f: A => Option[B]): Option[B] = {
-    // FIXME This should be tailrec but we seem to hit this bug
-    // https://github.com/scala/bug/issues/9647
-    var l = fa
-    var o: Option[B] = null
-    while (o == null) {
-      l match {
-        case LazyList.Nil() =>
-          o = None
-        case LazyList.Cons(h, t) =>
-          f(h()) match {
-            case Some(b) =>
-              o = Some(b)
-            case None =>
-              l = t()
-          }
+  def findMap[A, B](fa: LazyList[A])(f: A => Option[B]): Option[B] =
+    // TODO: Can we cast this?
+    findMapF(fa)(f.andThen(identity[Id[Option[B]]]))
+
+  def findMapF[F[_], A, B](fa: LazyList[A])(f: A => F[Option[B]])(implicit M: Monad[F]): F[Option[B]] =
+    M.tailRecM(fa) {
+      case LazyList.Nil() => M.point(Right(None))
+      case LazyList.Cons(h, t) => M.map(f(h())) {
+        case some: Some[B] => Right(some)
+        case None => Left(t())
       }
     }
-    o
-  }
 
   /** Performs the action `n` times, returning the list of results. */
   def replicateM[M[_], A](n: Int, fa: M[A])(implicit F: Applicative[M]): M[List[A]] =
@@ -68,8 +63,14 @@ package object predef {
 
   implicit val IdMonad: Monad[Id] =
     new Monad[Id] with StackSafeMonad[Id] {
-      override def bind[A, B](fa: Id[A])(f: A => Id[B]): Id[B] = f(fa)
-      override def point[A](a: => A): Id[A] = a
-      override def ap[A, B](fa: => Id[A])(f: => Id[A => B]): Id[B] = f(fa)
+      override def bind[A, B](fa: A)(f: A => B): B = f(fa)
+      override def point[A](a: => A): A = a
+      override def ap[A, B](fa: => A)(f: => A => B): B = f(fa)
+      @tailrec
+      override def tailRecM[A, B](a: A)(f: A => Either[A, B]): B =
+        f(a) match {
+          case Left(value) => tailRecM(value)(f)
+          case Right(value) => value
+        }
     }
 }

--- a/core/src/main/scala/hedgehog/predef/package.scala
+++ b/core/src/main/scala/hedgehog/predef/package.scala
@@ -63,4 +63,13 @@ package object predef {
       case h :: t =>
         F.ap(traverse(t)(f))(F.ap(f(h))(F.point((h2 : B) => (t2 : List[B]) => h2 :: t2)))
     }
+
+  type Id[A] = A
+
+  implicit val IdMonad: Monad[Id] =
+    new Monad[Id] with StackSafeMonad[Id] {
+      override def bind[A, B](fa: Id[A])(f: A => Id[B]): Id[B] = f(fa)
+      override def point[A](a: => A): Id[A] = a
+      override def ap[A, B](fa: => Id[A])(f: => Id[A => B]): Id[B] = f(fa)
+    }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.8

--- a/test/src/test/scala/hedgehog/StackSafeTest.scala
+++ b/test/src/test/scala/hedgehog/StackSafeTest.scala
@@ -1,0 +1,48 @@
+package hedgehog
+
+import hedgehog.core.PropertyT
+import hedgehog.predef.Monad
+
+import scala.annotation.tailrec
+import scala.language.higherKinds
+
+object StackSafeTest {
+
+  def propTailRecMIsStackSafe[F[_] : Monad](f: F[List[Int]] => PropertyT[List[Int]]): Property = {
+    for {
+      list <- genLazyStackSizes.forAll
+      sizes <- f(genStackSizes(list))
+    } yield sameSizes(sizes)
+  }
+
+  private def genLazyStackSizes: Gen[List[() => Int]] =
+    Gen.list(Gen.constant(stackSize), Range.linear(0, 10000))
+
+  private def stackSize =
+    () => Thread.currentThread.getStackTrace.length
+
+  private def genStackSizes[F[_]](lazyStackSizes: List[() => Int])(implicit M: Monad[F]): F[List[Int]] = {
+    type A = (List[() => Int], List[Int])
+    val zero: A = (lazyStackSizes, List.empty[Int])
+    M.tailRecM(zero) {
+      case (Nil, result) => M.point(Right(result))
+      case (head :: tail, result) => M.point(Left((tail, head() :: result)))
+    }
+  }
+
+  private def sameSizes(sizes: List[Int]): Result = {
+    @tailrec
+    def loop(baseSize: Option[Int], sizes: List[Int]): Result = sizes match {
+      case Nil => Result.success
+      case head :: tail => baseSize match {
+        case None => loop(Some(head), tail)
+        case Some(size) => size ==== head match {
+          case Result.Success => loop(baseSize, tail)
+          case failure: Result.Failure => failure
+        }
+      }
+    }
+
+    loop(None, sizes)
+  }
+}

--- a/test/src/test/scala/hedgehog/core/GenTTest.scala
+++ b/test/src/test/scala/hedgehog/core/GenTTest.scala
@@ -1,0 +1,12 @@
+package hedgehog.core
+
+import hedgehog._
+import hedgehog.runner._
+
+object GenTTest extends Properties {
+
+  override def tests: List[Test] =
+    List(
+      property("tailRecM is stack safe", StackSafeTest.propTailRecMIsStackSafe[GenT](_.forAll))
+    )
+}

--- a/test/src/test/scala/hedgehog/core/PropertyTTest.scala
+++ b/test/src/test/scala/hedgehog/core/PropertyTTest.scala
@@ -1,0 +1,12 @@
+package hedgehog.core
+
+import hedgehog._
+import hedgehog.runner._
+
+object PropertyTTest extends Properties {
+
+  override def tests: List[Test] =
+    List(
+      property("tailRecM is stack safe", StackSafeTest.propTailRecMIsStackSafe[PropertyT](identity))
+    )
+}

--- a/test/src/test/scala/hedgehog/core/TreeTest.scala
+++ b/test/src/test/scala/hedgehog/core/TreeTest.scala
@@ -1,0 +1,15 @@
+package hedgehog.core
+
+import hedgehog._
+import hedgehog.runner._
+
+object TreeTest extends Properties {
+
+  override def tests: List[Test] =
+    List(
+      property("tailRecM is stack safe", StackSafeTest.propTailRecMIsStackSafe[Tree](treeProperty))
+    )
+
+  private def treeProperty(tree: Tree[List[Int]]): PropertyT[List[Int]] =
+    GenT { (_, seed) => tree.map[(Seed, Option[List[Int]])](x => seed -> Some(x)) }.forAll
+}

--- a/test/src/test/scala/hedgehog/predef/EitherTest.scala
+++ b/test/src/test/scala/hedgehog/predef/EitherTest.scala
@@ -1,0 +1,19 @@
+package hedgehog.predef
+
+import hedgehog._
+import hedgehog.core.{GenT, PropertyT, Tree}
+import hedgehog.predef.Monad._
+import hedgehog.runner._
+
+object EitherTest extends Properties {
+
+  override def tests: List[Test] =
+    List(
+      property("tailRecM is stack safe", StackSafeTest.propTailRecMIsStackSafe[Either[Nothing, ?]](eitherProperty))
+    )
+
+  private def eitherProperty(either: Either[Nothing, List[Int]]): PropertyT[List[Int]] =
+    GenT {
+      case (_, seed) => implicitly[Applicative[Tree]].point((seed, either.right.toOption))
+    }.forAll
+}

--- a/test/src/test/scala/hedgehog/predef/IdTest.scala
+++ b/test/src/test/scala/hedgehog/predef/IdTest.scala
@@ -1,0 +1,16 @@
+package hedgehog.predef
+
+import hedgehog._
+import hedgehog.core.PropertyT
+import hedgehog.runner._
+
+object IdTest extends Properties {
+
+  override def tests: List[Test] =
+    List(
+      property("tailRecM is stack safe", StackSafeTest.propTailRecMIsStackSafe[Id](identityProperty))
+    )
+
+  private def identityProperty(id: Id[List[Int]]): PropertyT[List[Int]] =
+    Gen.constant(id).forAll
+}

--- a/test/src/test/scala/hedgehog/predef/IdentityTest.scala
+++ b/test/src/test/scala/hedgehog/predef/IdentityTest.scala
@@ -1,0 +1,16 @@
+package hedgehog.predef
+
+import hedgehog._
+import hedgehog.core.PropertyT
+import hedgehog.runner._
+
+object IdentityTest extends Properties {
+
+  override def tests: List[Test] =
+    List(
+      property("tailRecM is stack safe", StackSafeTest.propTailRecMIsStackSafe[Identity](identityProperty))
+    )
+
+  private def identityProperty(id: Identity[List[Int]]): PropertyT[List[Int]] =
+    Gen.constant(id.value).forAll
+}

--- a/test/src/test/scala/hedgehog/predef/StateTest.scala
+++ b/test/src/test/scala/hedgehog/predef/StateTest.scala
@@ -1,0 +1,16 @@
+package hedgehog.predef
+
+import hedgehog._
+import hedgehog.core.PropertyT
+import hedgehog.runner._
+
+object StateTest extends Properties {
+
+  override def tests: List[Test] =
+    List(
+      property("tailRecM is stack safe", StackSafeTest.propTailRecMIsStackSafe[StateT[Id, Any, ?]](stateProperty)(StateT.StateTMonad(IdMonad)))
+    )
+
+  private def stateProperty(state: StateT[Id, Any, List[Int]]): PropertyT[List[Int]] =
+    Gen.constant(state.run(0)._2).forAll
+}


### PR DESCRIPTION
An implementation of `hedgehog.core.PropertyTReporting#reportF` to support properties of type `PropertyT[F[Result]]`.

This requires the `Monad`s to implement a stack safe implementation of `tailRecM` which I copied from cats. It is based on [Stack Safety for Free](http://functorial.com/stack-safety-for-free/index.pdf).

Most of the current `Monad`s implement this using `bind` which is not stack safe. I'm not too sure what to do about these.

Remaining things to do are:
- [ ] Add a `Monad[Future]` instance.
- [ ] Resolve stack safety issues
- [ ] Do we need to provide a default implementation of `tailRecM` to maintain binary compatibility? What is the current approach to changes like these?
- [ ] Consider casting the `Id` types
- [ ] Remove incidental whitespace changes

Closes https://github.com/hedgehogqa/scala-hedgehog/issues/146