### PR TITLE
Fix build failure in publish to Bintray's maven repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,20 @@ script:
 after_success:
   - |
     if [ $TRAVIS_PULL_REQUEST == "false" ] && ([ "${TRAVIS_BRANCH:-}" == "master" ] || [ "${TRAVIS_TAG:-}" != "" ]); then
-      sbt ++${TRAVIS_SCALA_VERSION}! 'set version in ThisBuild := "'$VERSION'"' "set publishMavenStyle in ThisBuild := false" publish
+      sbt ++${TRAVIS_SCALA_VERSION}! \
+        'set version in ThisBuild := "'$VERSION'"' \
+        "set publishMavenStyle in ThisBuild := false" \
+        publish
       # Keep publishing to the "generic" bintray repository
-      sbt ++${TRAVIS_SCALA_VERSION}! 'set version in ThisBuild := "'$VERSION'"' "set publishMavenStyle in ThisBuild := true" publish
+      sbt ++${TRAVIS_SCALA_VERSION}! \
+        'set version in ThisBuild := "'$VERSION'"' \
+        "set publishMavenStyle in ThisBuild := true" \
+        publish
       # Publish to the "maven" bintray repository as well
       export BINTRAY_REPO=${BINTRAY_REPO:-scala-hedgehog-maven}
       sbt ++${TRAVIS_SCALA_VERSION}! \
         'set version in ThisBuild := "'$VERSION'"' \
         'set publishMavenStyle in ThisBuild := true' \
-        'set bintrayRepository in ThisBuild := "'$BINTRAY_REPO'"' \
         publish
       if [ "${TRAVIS_TAG:-}" != "" ]; then
         export VERSION

--- a/build.sbt
+++ b/build.sbt
@@ -132,6 +132,6 @@ lazy val testingSettings = Seq(
 
 lazy val bintrarySettings = Seq(
     bintrayOrganization := Some("hedgehogqa")
-  , bintrayRepository := "scala-hedgehog"
+  , bintrayRepository := sys.env.getOrElse("BINTRAY_REPO", "scala-hedgehog")
   , licenses += ("Apache-2.0", url("https://opensource.org/licenses/Apache-2.0"))
   )


### PR DESCRIPTION
Issue #145 - Publish to Maven Central
- Fix build failure in publish to Bintray's maven repo

An example of the failure: https://travis-ci.org/github/hedgehogqa/scala-hedgehog/jobs/694438190#L756

This happened because `set something in ThisBuild` (e.g. `'set bintrayRepository in ThisBuild := "'$BINTRAY_REPO'"'`) does not override any sub-project specific setup so each publish candidate project still uses the one set in the `build.sbt`. Therefore the `set bintrayRepository` above has no impact on `sbt publish`.

So after all, it is good to use ENV vars to solve the publish issue.

I tested it by publishing to my own repos.

e.g.)
* The generic repo (ivy and maven)
  https://bintray.com/kevinlee/scala-hedgehog/hedgehog-core/0413f472b2742b0b8ae9f76be3bec943cf319ba1#files
* The maven one
  https://bintray.com/kevinlee/scala-hedgehog-maven/hedgehog-core/0413f472b2742b0b8ae9f76be3bec943cf319ba1#files/%5BLjava.lang.String%3B%40398c7a47