### PR TITLE
Update: README.md - put the generic repo back

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ libraryDependencies ++= Seq(
   "qa.hedgehog" %% "hedgehog-sbt" % hedgehogVersion
 )
 
-resolvers += "bintray-scala-hedgehog" at "https://dl.bintray.com/hedgehogqa/scala-hedgehog-maven"
+resolvers += "bintray-scala-hedgehog" at "https://dl.bintray.com/hedgehogqa/scala-hedgehog"
 ```
 
 ### SBT Source Dependency


### PR DESCRIPTION
Update: README.md - put the generic repo back to use commit hash based version

Sorry I forgot to update it before.