### PR TITLE
Allow deterministic seeds via environment variable

### DIFF
--- a/core/shared/src/main/scala/hedgehog/core/Seed.scala
+++ b/core/shared/src/main/scala/hedgehog/core/Seed.scala
@@ -46,10 +46,10 @@ object Seed {
 
   // FIX: predef IO
   def fromTime(): Seed =
-    fromSeedSource(SeedSource.FromTime(System.nanoTime))
+    fromSeedSource(SeedSource.fromTime(System.nanoTime))
 
   def fromLong(seed: Long): Seed =
-    Seed(MersenneTwister64.fromSeed(seed), SeedSource.FromLong(seed))
+    Seed(MersenneTwister64.fromSeed(seed), SeedSource.fromLong(seed))
   
   def fromSeedSource(source: SeedSource): Seed =
     Seed(MersenneTwister64.fromSeed(source.seed), source)
@@ -58,8 +58,8 @@ object Seed {
     val source = sys.env
       .get("HEDGEHOG_SEED")
       .flatMap(s => scala.util.Try(s.toLong).toOption)
-      .map(SeedSource.FromEnv)
-      .getOrElse(SeedSource.FromTime(System.nanoTime()))
+      .map(SeedSource.fromEnv)
+      .getOrElse(SeedSource.fromTime(System.nanoTime()))
     Seed.fromSeedSource(source)
   }
 }
@@ -76,6 +76,10 @@ sealed trait SeedSource extends Product with Serializable {
   }
 }
 object SeedSource {
+  def fromTime(seed: Long): SeedSource = FromTime(seed)
+  def fromEnv(seed: Long): SeedSource = FromEnv(seed)
+  def fromLong(seed: Long): SeedSource = FromLong(seed)
+
   final case class FromTime(seed: Long) extends SeedSource
   final case class FromEnv(seed: Long) extends SeedSource
   final case class FromLong(seed: Long) extends SeedSource

--- a/core/shared/src/main/scala/hedgehog/core/Seed.scala
+++ b/core/shared/src/main/scala/hedgehog/core/Seed.scala
@@ -50,5 +50,19 @@ object Seed {
 
   def fromLong(seed: Long): Seed =
     Seed(MersenneTwister64.fromSeed(seed))
+
+  def fromEnvOrTime(loggers: Iterable[String => Unit]): Seed = {
+    val (seed, logOutput) = sys.env
+      .get("HEDGEHOG_SEED")
+      .flatMap(s => scala.util.Try(s.toLong).toOption) match {
+        case Some(seedFromEnv) => 
+          (seedFromEnv, s"Using seed from environment variable HEDGEHOG_SEED: $seedFromEnv")
+        case None =>
+          val seedFromTime = System.nanoTime()
+          (seedFromTime, s"Using random seed: $seedFromTime")
+      }
+    loggers.foreach(log => log(logOutput))
+    Seed.fromLong(seed)
+  }
 }
 

--- a/core/shared/src/main/scala/hedgehog/core/Seed.scala
+++ b/core/shared/src/main/scala/hedgehog/core/Seed.scala
@@ -52,31 +52,3 @@ object Seed {
     Seed(MersenneTwister64.fromSeed(seed))
 }
 
-sealed trait SeedSource extends Product with Serializable {
-  def seed: Long
-  def renderLog: String = this match {
-    case SeedSource.FromTime(seed) => 
-      s"Using random seed: $seed"
-    case SeedSource.FromEnv(seed) => 
-      s"Using seed from environment variable HEDGEHOG_SEED: $seed"
-    case SeedSource.FromLong(seed) =>
-      s"Using seed: $seed"
-  }
-}
-object SeedSource {
-  def fromTime(seed: Long): SeedSource = FromTime(seed)
-  def fromEnv(seed: Long): SeedSource = FromEnv(seed)
-  def fromLong(seed: Long): SeedSource = FromLong(seed)
-
-  def fromEnvOrTime(): SeedSource =
-    sys.env
-      .get("HEDGEHOG_SEED")
-      .flatMap(s => scala.util.Try(s.toLong).toOption)
-      .map(SeedSource.fromEnv)
-      .getOrElse(SeedSource.fromTime(System.nanoTime()))
-
-  final case class FromTime(seed: Long) extends SeedSource
-  final case class FromEnv(seed: Long) extends SeedSource
-  final case class FromLong(seed: Long) extends SeedSource
-}
-

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -639,6 +639,35 @@ List(0)
 You can see after a few tries Hedgehog finds an invalid example `List(1, 4, 1)`,
 and starts to shrink both the values down to `0` and also the list size.
 
+### Deterministic results
+
+By default, Hedgehog uses a random seed that is based on the current system time. Normally, this is exactly what you want. However, if you have a failing test, the randomness of the generated test data can make it very difficult to reproduce and analyse the problem — especially if the test is only failing sporadically. In this situation, it would be better if you could get exactly the same generated test data that caused the test to fail.
+
+This is why Hedgehog logs the seed together with the test results. In your console, you should see something like this:
+
+```
+Using random seed: 58973622580784
++ hedgehog.PropertyTest$.example1: OK, passed 1 tests
++ hedgehog.PropertyTest$.applicative: OK, passed 1 tests
++ hedgehog.PropertyTest$.applicative shrink: OK, passed 100 tests
+```
+
+Now imagine of these tests fails sporadically in your build pipeline. To analyse the problem locally, you can reproduce this test run by setting the seed to the same value. All you need to do is set the environment variable `HEDGEHOG_SEED` to the value in question.
+
+Example:
+
+```
+export HEDGEHOG_SEED=58973622580784
+```
+
+Now you can reproduce the test run you're interested in. Hedgehog will inform you that it used the seed from the environment variable:
+
+```
+Using seed from environment variable HEDGEHOG_SEED: 58973622580784
++ hedgehog.PropertyTest$.example1: OK, passed 1 tests
++ hedgehog.PropertyTest$.applicative: OK, passed 1 tests
++ hedgehog.PropertyTest$.applicative shrink: OK, passed 100 tests
+```
 
 ## State
 

--- a/runner/shared/src/main/scala/hedgehog/runner/Properties.scala
+++ b/runner/shared/src/main/scala/hedgehog/runner/Properties.scala
@@ -12,7 +12,8 @@ abstract class Properties {
   /** Allows the implementing test to be run separately without SBT */
   def main(args: Array[String]): Unit = {
     val config = PropertyConfig.default
-    val seed = Seed.fromEnvOrTime(Some((s: String) => println(s)))
+    val seed = Seed.fromEnvOrTime()
+    println(seed.source.renderLog)
     tests.foreach(t => {
       val report = Property.check(t.withConfig(config), t.result, seed)
       println(Test.renderReport(this.getClass.getName, t, report, ansiCodesSupported = true))

--- a/runner/shared/src/main/scala/hedgehog/runner/Properties.scala
+++ b/runner/shared/src/main/scala/hedgehog/runner/Properties.scala
@@ -12,8 +12,9 @@ abstract class Properties {
   /** Allows the implementing test to be run separately without SBT */
   def main(args: Array[String]): Unit = {
     val config = PropertyConfig.default
-    val seed = Seed.fromEnvOrTime()
-    println(seed.source.renderLog)
+    val seedSource = SeedSource.fromEnvOrTime()
+    val seed = Seed.fromLong(seedSource.seed)
+    println(seedSource.renderLog)
     tests.foreach(t => {
       val report = Property.check(t.withConfig(config), t.result, seed)
       println(Test.renderReport(this.getClass.getName, t, report, ansiCodesSupported = true))

--- a/runner/shared/src/main/scala/hedgehog/runner/Properties.scala
+++ b/runner/shared/src/main/scala/hedgehog/runner/Properties.scala
@@ -12,7 +12,7 @@ abstract class Properties {
   /** Allows the implementing test to be run separately without SBT */
   def main(args: Array[String]): Unit = {
     val config = PropertyConfig.default
-    val seed = Seed.fromTime()
+    val seed = Seed.fromEnvOrTime(Some((s: String) => println(s)))
     tests.foreach(t => {
       val report = Property.check(t.withConfig(config), t.result, seed)
       println(Test.renderReport(this.getClass.getName, t, report, ansiCodesSupported = true))

--- a/runner/shared/src/main/scala/hedgehog/runner/SeedSource.scala
+++ b/runner/shared/src/main/scala/hedgehog/runner/SeedSource.scala
@@ -1,0 +1,29 @@
+package hedgehog.runner
+
+sealed trait SeedSource extends Product with Serializable {
+  def seed: Long
+  def renderLog: String = this match {
+    case SeedSource.FromTime(seed) => 
+      s"Using random seed: $seed"
+    case SeedSource.FromEnv(seed) => 
+      s"Using seed from environment variable HEDGEHOG_SEED: $seed"
+    case SeedSource.FromLong(seed) =>
+      s"Using seed: $seed"
+  }
+}
+object SeedSource {
+  def fromTime(seed: Long): SeedSource = FromTime(seed)
+  def fromEnv(seed: Long): SeedSource = FromEnv(seed)
+  def fromLong(seed: Long): SeedSource = FromLong(seed)
+
+  def fromEnvOrTime(): SeedSource =
+    sys.env
+      .get("HEDGEHOG_SEED")
+      .flatMap(s => scala.util.Try(s.toLong).toOption)
+      .map(SeedSource.fromEnv)
+      .getOrElse(SeedSource.fromTime(System.nanoTime()))
+
+  final case class FromTime(seed: Long) extends SeedSource
+  final case class FromEnv(seed: Long) extends SeedSource
+  final case class FromLong(seed: Long) extends SeedSource
+}

--- a/sbt-test/shared/src/main/scala/hedgehog/sbt/Framework.scala
+++ b/sbt-test/shared/src/main/scala/hedgehog/sbt/Framework.scala
@@ -92,7 +92,8 @@ class Task(
 
   private def run(eventHandler: sbtt.EventHandler, loggers: Array[sbtt.Logger]) = {
     val config = PropertyConfig.default
-    val seed = Seed.fromEnvOrTime(loggers.map(logger => logger.info(_)))
+    val seed = Seed.fromEnvOrTime()
+    loggers.foreach(logger => logger.info(seed.source.renderLog))
     val properties =
       if (fingerprint.isModule) {
         Reflect.lookupLoadableModuleClass(taskDef.fullyQualifiedName + "$", testClassLoader).get.loadModule().asInstanceOf[Properties]

--- a/sbt-test/shared/src/main/scala/hedgehog/sbt/Framework.scala
+++ b/sbt-test/shared/src/main/scala/hedgehog/sbt/Framework.scala
@@ -92,8 +92,9 @@ class Task(
 
   private def run(eventHandler: sbtt.EventHandler, loggers: Array[sbtt.Logger]) = {
     val config = PropertyConfig.default
-    val seed = Seed.fromEnvOrTime()
-    loggers.foreach(logger => logger.info(seed.source.renderLog))
+    val seedSource = SeedSource.fromEnvOrTime()
+    val seed = Seed.fromLong(seedSource.seed)
+    loggers.foreach(logger => logger.info(seedSource.renderLog))
     val properties =
       if (fingerprint.isModule) {
         Reflect.lookupLoadableModuleClass(taskDef.fullyQualifiedName + "$", testClassLoader).get.loadModule().asInstanceOf[Properties]


### PR DESCRIPTION
To allow easier analysis of failed tests, allow setting the seed from an environment variable `HEDGEHOD_SEED`. Also log the used seed so it can be copy-pasted for the purpose described.

So far, I have only implemented this for the sbt runner, not for the main method of the `Properties` class. This is because I would first like to get some feedback on the soundness of this approach.

Currently, I always log the seed before running the tests of a single `Properties` class. Would you prefer to only log this in case a property failed?

This closes #156