### PR TITLE
Update to Scala 2.12.11 and 2.13.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 scala:
  - 2.11.12
- - 2.12.8
- - 2.13.0
+ - 2.12.11
+ - 2.13.3
 script:
   - |
     if [ "${TRAVIS_TAG:-}" != "" ]; then

--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,8 @@ ThisBuild / scmInfo := Some(
       "scm:git@github.com:hedgehogqa/scala-hedgehog.git"
     )
   )
-ThisBuild / scalaVersion := "2.12.8"
-ThisBuild / crossScalaVersions := Seq("2.11.12", scalaVersion.value, "2.13.0")
+ThisBuild / scalaVersion := "2.12.11"
+ThisBuild / crossScalaVersions := Seq("2.11.12", scalaVersion.value, "2.13.3")
 
 lazy val hedgehog = Project(
     id = "hedgehog"


### PR DESCRIPTION
The previous versions were a bit outdated. While not a problem per se, it does result in a warning when using the Metals extension, because it will drop support for those specific minor versions in a while.