### PR TITLE
Minitest integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ While Hedgehog is obviously not included in that list, an may never  be, by exte
 `Properties` tests can be run as an application (as `Properties` includes a handy `main` function).
 NOTE: This requires the test to be an `object` and _not_ a `class`.
 
-
 ## Example
 
 See the [examples](example/shared/src/main/scala/hedgehog/examples/) module for working versions.
@@ -121,6 +120,40 @@ object PropertyTest extends Properties {
     for {
       xs <- Gen.alpha.list(Range.linear(0, 100)).forAll
     } yield xs.reverse.reverse ==== xs
+}
+```
+
+## Integration with other test libraries
+
+### Minitest
+
+Scala Hedgehog provides an integration module for [minitest](github.com/monix/minitest). This allows you to define property-based and example-based Hedgehog tests within a minitest test suite. If you use this integration, you won't need to Scala Hedgehog sbt testing extension, because you're using the one provided by minitest:
+
+```scala
+val hedgehogVersion = "${COMMIT}"
+libraryDependencies ++= "qa.hedgehog" %% "hedgehog-minitest" % hedgehogVersion
+
+resolvers += "bintray-scala-hedgehog" at "https://dl.bintray.com/hedgehogqa/scala-hedgehog"
+
+testFrameworks += new TestFramework("minitest.runner.Framework")
+```
+
+Here's an example of using `hedgehog-minitest`:
+
+```scala
+import minitest.SimpleTestSuite
+import hedgehog.minitest.HedgehogSupport
+import hedgehog._
+
+object ReverseTest extends SimpleTestSuite with HedgehogSupport {
+  property("reverse alphabetic strings") {
+    for {
+      xs <- Gen.alpha.list(Range.linear(0, 100)).forAll
+    } yield xs.reverse.reverse ==== xs
+  }
+  example("reverse hello") {
+    "hello".reverse ==== "olleh"
+  }
 }
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val hedgehog = Project(
   )
   .settings(standardSettings)
   .settings(noPublish)
-  .aggregate(coreJVM, coreJS, runnerJVM, runnerJS, sbtTestJVM, sbtTestJS, testJVM, testJS, exampleJVM, exampleJS)
+  .aggregate(coreJVM, coreJS, runnerJVM, runnerJS, sbtTestJVM, sbtTestJS, testJVM, testJS, exampleJVM, exampleJS, minitestJVM, minitestJS)
 
 lazy val core = crossProject(JVMPlatform, JSPlatform)
   .in(file("core"))
@@ -87,6 +87,18 @@ lazy val sbtTest = crossProject(JVMPlatform, JSPlatform)
   .dependsOn(core, runner)
 lazy val sbtTestJVM = sbtTest.jvm
 lazy val sbtTestJS = sbtTest.js
+
+lazy val minitest = crossProject(JVMPlatform, JSPlatform)
+  .in(file("minitest"))
+  .settings(standardSettings ++ bintrarySettings ++ Seq(
+    name := "hedgehog-minitest"
+  ) ++ Seq(libraryDependencies ++= Seq(
+      "org.portable-scala" %%% "portable-scala-reflect" % "1.0.0",
+      "io.monix" %%% "minitest" % "2.8.2"
+    )) ++ Seq(testFrameworks += TestFramework("minitest.runner.Framework"))
+  ).dependsOn(runner)
+lazy val minitestJVM = minitest.jvm
+lazy val minitestJS = minitest.js
 
 lazy val test = crossProject(JVMPlatform, JSPlatform)
   .settings(standardSettings ++ noPublish ++ Seq(

--- a/minitest/shared/src/main/scala/hedgehog/minitest/HedgehogSupport.scala
+++ b/minitest/shared/src/main/scala/hedgehog/minitest/HedgehogSupport.scala
@@ -1,0 +1,39 @@
+package hedgehog.minitest
+
+import minitest.SimpleTestSuite
+import hedgehog.runner.{SeedSource, Test}
+import hedgehog.core.{PropertyConfig, Seed, Status}
+import hedgehog.{Property, Result}
+
+trait HedgehogSupport { self: SimpleTestSuite =>
+  private val seedSource = SeedSource.fromEnvOrTime()
+  private val seed: Seed = Seed.fromLong(seedSource.seed)
+
+  def property(name: String, config: PropertyConfig = PropertyConfig.default)(
+      prop: => Property
+  ): Unit = {
+    val t = hedgehog.runner.property(name, prop)
+    test(name)(check(t, config))
+  }
+
+  def example(name: String, config: PropertyConfig = PropertyConfig.default)(
+      result: => Result
+  ): Unit = {
+    val t = hedgehog.runner.example(name, result)
+    test(name)(check(t, config))
+  }
+
+  private def check(test: Test, config: PropertyConfig): Unit = {
+    val report = Property.check(config, test.result, seed)
+    if (report.status != Status.ok) {
+      val reason = Test.renderReport(
+        this.getClass.getName,
+        test,
+        report,
+        ansiCodesSupported = true
+      )
+      val reasonWithSeed = s"$reason\n${seedSource.renderLog}"
+      fail(reasonWithSeed)
+    }
+  }
+}

--- a/minitest/shared/src/main/scala/hedgehog/minitest/HedgehogSupport.scala
+++ b/minitest/shared/src/main/scala/hedgehog/minitest/HedgehogSupport.scala
@@ -9,18 +9,18 @@ trait HedgehogSupport { self: SimpleTestSuite =>
   private val seedSource = SeedSource.fromEnvOrTime()
   private val seed: Seed = Seed.fromLong(seedSource.seed)
 
-  def property(name: String, config: PropertyConfig = PropertyConfig.default)(
+  def property(name: String, withConfig: PropertyConfig => PropertyConfig = identity)(
       prop: => Property
   ): Unit = {
-    val t = hedgehog.runner.property(name, prop)
-    test(name)(check(t, config))
+    val t = hedgehog.runner.property(name, prop).config(withConfig)
+    test(name)(check(t, t.withConfig(PropertyConfig.default)))
   }
 
-  def example(name: String, config: PropertyConfig = PropertyConfig.default)(
+  def example(name: String, withConfig: PropertyConfig => PropertyConfig = identity)(
       result: => Result
   ): Unit = {
-    val t = hedgehog.runner.example(name, result)
-    test(name)(check(t, config))
+    val t = hedgehog.runner.example(name, result).config(withConfig)
+    test(name)(check(t, t.withConfig(PropertyConfig.default)))
   }
 
   private def check(test: Test, config: PropertyConfig): Unit = {

--- a/minitest/shared/src/main/scala/hedgehog/minitest/HedgehogSupport.scala
+++ b/minitest/shared/src/main/scala/hedgehog/minitest/HedgehogSupport.scala
@@ -24,7 +24,7 @@ trait HedgehogSupport { self: SimpleTestSuite =>
   }
 
   private def check(test: Test, config: PropertyConfig): Unit = {
-    val report = Property.check(config, test.result, seed)
+    val report = Property.check(test.withConfig(config), test.result, seed)
     if (report.status != Status.ok) {
       val reason = Test.renderReport(
         this.getClass.getName,

--- a/minitest/shared/src/test/scala/hedgehog/minitest/MinitestIntegrationTest.scala
+++ b/minitest/shared/src/test/scala/hedgehog/minitest/MinitestIntegrationTest.scala
@@ -1,0 +1,20 @@
+package hedgehog.minitest
+
+import minitest.SimpleTestSuite
+import hedgehog.core.Result
+import hedgehog._
+
+object MinitestIntegrationTest extends SimpleTestSuite with HedgehogSupport {
+  test("standard minitest test case") {
+    assert(3 + 5 == 8)
+  }
+  example("hedgehog example as minitest test case") {
+    Result.assert(3 + 5 == 8)  
+  }
+  property("hedgehog property as minitest test case") {
+    for {
+      x <- Gen.int(Range.linear(-500, 500)).forAll
+      y <- Gen.int(Range.linear(-500, 500)).forAll  
+    } yield x + y ==== y + x
+  }
+}


### PR DESCRIPTION
This PR provides a new sbt sub module for integrating with [minitest](https://github.com/monix/minitest). It allows users of minitest to define properties and examples using a style and syntax that is familiar to them. The diff also contains documentation on how to use this module, including a small example test.

This closes #160.