### PR TITLE
Log before ending - avoid losing the report printing

### DIFF
--- a/sbt-test/shared/src/main/scala/hedgehog/sbt/Framework.scala
+++ b/sbt-test/shared/src/main/scala/hedgehog/sbt/Framework.scala
@@ -105,9 +105,8 @@ class Task(
       val startTime = System.currentTimeMillis
       val report = Property.check(t.withConfig(config), t.result, seed)
       val endTime = System.currentTimeMillis
-      eventHandler.handle(Event.fromReport(taskDef, new sbtt.TestSelector(t.name), report, endTime - startTime))
-
       loggers.foreach(logger => logger.info(Test.renderReport(taskDef.fullyQualifiedName(), t, report, logger.ansiCodesSupported())))
+      eventHandler.handle(Event.fromReport(taskDef, new sbtt.TestSelector(t.name), report, endTime - startTime))
     })
   }
 }


### PR DESCRIPTION
This is just an educated guess: it looks to me like it's possible
hedgehog-sbt is racing sbt here on whether the messages sent to logger
will be unbuffered in time or not.  Let's make sure those messages are
in the buffer before sending the event.

Fixes #132 (optimistically)