### PR TITLE
Add: hedgehog-minitest to Maven Central sync

### DIFF
--- a/ci/bintray_maven_central_sync
+++ b/ci/bintray_maven_central_sync
@@ -7,7 +7,7 @@
 BINTRAY_SUBJECT=${BINTRAY_SUBJECT:-hedgehogqa}
 BINTRAY_REPO=${BINTRAY_REPO:-scala-hedgehog-maven}
 
-BINTRAY_PACKAGES="hedgehog-core hedgehog-runner hedgehog-sbt"
+BINTRAY_PACKAGES="hedgehog-core hedgehog-runner hedgehog-sbt hedgehog-minitest"
 
 echo "Sync to Maven Central..."
 
@@ -17,7 +17,6 @@ for bintray_package in $BINTRAY_PACKAGES; do
 
   # https://bintray.com/docs/api/#_sync_version_artifacts_to_maven_central
   curl \
-    -f \
     --user "${BINTRAY_USER}:${BINTRAY_PASS}" \
     -X POST \
     -d '{}' \


### PR DESCRIPTION
Add: hedgehog-minitest to Maven Central sync.

As discussed already, please make sure the new bintray repo for `hedgehog-minitest` is linked to JCentre if merging this PR.
<img width="394" alt="Screen Shot 2020-07-23 at 1 22 39 am" src="https://user-images.githubusercontent.com/2307335/88788813-36758000-d1d9-11ea-8293-f49005ef05e6.png">

I removed `-f` param from `curl` command for debugging. Currently Maven Central sync is not working. ☹️
