### PR TITLE
Disable release build in forked repos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - master
+
   pull_request:
     branches:
       - master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build_and_publish:
+    if: github.repository == 'hedgehogqa/scala-hedgehog'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Current GitHub Actions config runs release build in forked repos so it should be turned off.
This PR disables the release build in forked repos.