### PR TITLE
Tag build publishes to only the Maven repo.

### DIFF
--- a/.github/workflows/publish.sh
+++ b/.github/workflows/publish.sh
@@ -7,19 +7,27 @@ echo "  SCALA_VERSION=$SCALA_VERSION"
 echo "PROJECT_VERSION=$PROJECT_VERSION"
 echo "   BINTRAY_REPO=$BINTRAY_REPO"
 
-echo "sbt publish no maven style to $BINTRAY_REPO"
+if [[ -z "${GITHUB_TAG}" ]]
+then
+  echo "It is not a tag build."
 
-sbt ++${SCALA_VERSION}! \
-  'set version in ThisBuild := "'$PROJECT_VERSION'"' \
-  "set publishMavenStyle in ThisBuild := false" \
-  publish
+  echo "sbt publish no maven style to $BINTRAY_REPO"
 
-echo "sbt publish maven style to $BINTRAY_REPO"
-# Keep publishing to the "generic" bintray repository
-sbt ++${SCALA_VERSION}! \
-  'set version in ThisBuild := "'$PROJECT_VERSION'"' \
-  "set publishMavenStyle in ThisBuild := true" \
-  publish
+  sbt ++${SCALA_VERSION}! \
+    'set version in ThisBuild := "'$PROJECT_VERSION'"' \
+    "set publishMavenStyle in ThisBuild := false" \
+    publish
+
+  echo "sbt publish maven style to $BINTRAY_REPO"
+  # Keep publishing to the "generic" bintray repository
+  sbt ++${SCALA_VERSION}! \
+    'set version in ThisBuild := "'$PROJECT_VERSION'"' \
+    "set publishMavenStyle in ThisBuild := true" \
+    publish
+
+else
+  echo "It is a tag build. GITHUB_TAG=${GITHUB_TAG}"
+fi
 
 export BINTRAY_REPO=${BINTRAY_REPO:-scala-hedgehog-maven}
 echo "sbt publish maven style to $BINTRAY_REPO"

--- a/build.sbt
+++ b/build.sbt
@@ -22,8 +22,12 @@ lazy val standardSettings: Seq[Setting[_]] = Seq(
         (if (isDotty.value) false else (Compile / packageDoc / publishArtifact).value)
     , packageDoc / publishArtifact :=
         (if (isDotty.value) false else (packageDoc / publishArtifact).value)
-    , Compile / doc / sources :=
-        (if (isDotty.value) Seq.empty[File] else (Compile / doc / sources).value)
+    , Compile / doc / sources := (Def.taskDyn {
+        (if (isDotty.value)
+          Def.task(Seq.empty[File])
+        else
+          Def.task((Compile / doc / sources).value))
+      }).value
     )
   ).flatten
 


### PR DESCRIPTION
## Tag build publishes to only the Maven repo.
* Non-tag build still publishes to both Ivy and Maven repos.
* It is not reduce the number of publish requests sent to Bintray.

Unfortunately, [the tag build fails due to the bintray publish request timeout](https://github.com/hedgehogqa/scala-hedgehog/runs/1424443511?check_suite_focus=true). So I'm trying to reduce the number of publish requests.

It is also unnecessary to publish to the Ivy repo when it's a tag build since it will be available in the Maven Central anyway.