### PR TITLE
Fix: issues with Scala 3.0.0-M3

### DIFF
--- a/core/shared/src/main/scala/hedgehog/predef/package.scala
+++ b/core/shared/src/main/scala/hedgehog/predef/package.scala
@@ -13,7 +13,7 @@ package hedgehog
  */
 package object predef {
 
-  implicit def EitherOps[L, R](e: Either[L, R]): EitherOps[L, R] =
+  implicit def eitherOps[L, R](e: Either[L, R]): EitherOps[L, R] =
     new EitherOps(e)
 
   type State[S, A] = StateT[Identity, S, A]

--- a/example/shared/src/main/scala/hedgehog/examples/PropertyTest.scala
+++ b/example/shared/src/main/scala/hedgehog/examples/PropertyTest.scala
@@ -45,16 +45,16 @@ object PropertyTest extends Properties {
   def cheap: Gen[Item] =
     for {
       n <- element("sandwich", List("noodles"))
-      p <- long(Range.constant(5, 10)).map(USD)
+      p <- long(Range.constant(5, 10)).map(USD.apply)
     } yield Item(n, p)
 
   def expensive: Gen[Item] =
     for {
       n <- element("oculus", List("vive"))
-      p <- long(Range.linear(1000, 2000)).map(USD)
+      p <- long(Range.linear(1000, 2000)).map(USD.apply)
     } yield Item(n, p)
 
   def order(gen: Gen[Item]): Gen[Order] =
-    gen.list(Range.linear(0, 50)).map(Order)
+    gen.list(Range.linear(0, 50)).map(Order.apply)
 
 }

--- a/test/jvm/src/test/scala/hedgehog/state/StateTest.scala
+++ b/test/jvm/src/test/scala/hedgehog/state/StateTest.scala
@@ -348,7 +348,7 @@ object Vars {
           case Nil =>
             None
           case h :: t =>
-            Some(Gen.element(h, t).map(Execute))
+            Some(Gen.element(h, t).map(Execute.apply))
         }
 
       override def execute(env: Environment, s: Input): Either[String, Output] =

--- a/test/shared/src/test/scala/hedgehog/PropertyTest.scala
+++ b/test/shared/src/test/scala/hedgehog/PropertyTest.scala
@@ -88,17 +88,17 @@ object PropertyTest extends Properties {
   def cheap: Gen[Item] =
     for {
       n <- element("sandwich", List("noodles"))
-      p <- long(Range.constant(5, 10)).map(USD)
+      p <- long(Range.constant(5, 10)).map(USD.apply)
     } yield Item(n, p)
 
   def expensive: Gen[Item] =
     for {
       n <- element("oculus", List("vive"))
-      p <- long(Range.linear(1000, 2000)).map(USD)
+      p <- long(Range.linear(1000, 2000)).map(USD.apply)
     } yield Item(n, p)
 
   def order(gen: Gen[Item]): Gen[Order] =
-    gen.list(Range.linear(0, 50)).map(Order)
+    gen.list(Range.linear(0, 50)).map(Order.apply)
 
   def total: Result = {
     val seed = Seed.fromLong(5489)


### PR DESCRIPTION
Fix: issues with Scala 3.0.0-M3.
* Scala 3.0.0-M3 complains about having two `EitherOps`s.
* Also getting errors for `apply` method insertion.
  e.g.)
  ```scala
  Gen.element(h, t).map(Execute)
  ```
  results in
  ```
  Some(Gen.element(h, t).map(Execute))
                             ^^^^^^^
  The method `apply` is inserted. The auto insertion will be deprecated, please write `hedgehog.state.Vars.Execute.apply` explicitly.
  ```