### PR TITLE
Adds munit integration for hedgehog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           RUN_NUMBER: ${{ github.run_number }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "Rull request to the '${CURRENT_BRANCH_NAME}' branch"
+          echo "Pull request to the '${CURRENT_BRANCH_NAME}' branch"
           echo "RUN_ID=${RUN_ID}"
           echo "RUN_NUMBER=${RUN_NUMBER}"
           echo "PR #${PR_NUMBER}"

--- a/docs/integration/munit.md
+++ b/docs/integration/munit.md
@@ -1,0 +1,41 @@
+---
+title: 'Integration with other test libraries'
+sidebar_label: 'munit'
+slug: '/integration-munit'
+---
+## Integration with other test libraries
+
+### munit
+
+Scala Hedgehog provides an integration module for [munit](https://scalameta.org/munit/). This allows you to define property-based and example-based Hedgehog tests within a munit test suite. If you use this integration, you won't need to Scala Hedgehog sbt testing extension, because you're using the one provided by munit:
+
+```scala
+val hedgehogVersion = "@VERSION@"
+libraryDependencies += "qa.hedgehog" %% "hedgehog-munit" % hedgehogVersion
+
+testFrameworks += TestFramework("munit.runner.Framework")
+```
+
+Here's an example of using `hedgehog-munit`:
+
+```scala
+import hedgehog.munit.HedgehogSuite
+import hedgehog._
+
+class ReverseSuite extends HedgehogSuite {
+  property("reverse alphabetic strings") {
+    for {
+      xs <- Gen.alpha.list(Range.linear(0, 100)).forAll
+    } yield assertEquals(xs.reverse.reverse, xs)
+  }
+  
+  test("reverse hello") {
+    withMunitAssertions{ assertions =>
+	  asertions.assertEqual("hello".reverse, "olleh")
+	}
+    "hello".reverse ==== "olleh"
+  }
+}
+```
+
+HedgehogSuite provides `munit`-like assertions, along with all the `hedgehog.Result` methods and members, that return results in the standard hedgehog report format while satisfying munit's exception-based test failures.

--- a/munit/js/src/test/scala-2/hedgehog/munit/HedgehogAssertionsSuite.scala
+++ b/munit/js/src/test/scala-2/hedgehog/munit/HedgehogAssertionsSuite.scala
@@ -1,0 +1,774 @@
+package hedgehog
+package munit
+
+import hedgehog.core.Log
+import _root_.munit.Assertions
+import _root_.munit.FunSuite
+import scala.annotation.nowarn
+
+@nowarn
+class HedgehogAssertionsSuite extends FunSuite {
+
+  val instance = FunFixture[HedgehogAssertions](
+    setup = { test =>
+      new HedgehogAssertions with Assertions {}
+    },
+    teardown = { suite => () }
+  )
+
+  val resultSuccess =
+    FunFixture[Result](setup = test => Result.success, teardown = suite => ())
+
+  val resultFailure =
+    FunFixture[Result](setup = test => Result.failure, teardown = suite => ())
+
+  val results = FunFixture.map2(resultSuccess, resultFailure)
+
+  val instanceAndResults =
+    FunFixture.map3(instance, resultSuccess, resultFailure)
+
+  val exampleOne = FunFixture[Int](setup = test => 1, teardown = suite => ())
+
+  val exampleTwo = FunFixture[Int](setup = test => 2, teardown = suite => ())
+
+  val comparisonFunction = FunFixture[(Int, Int) => Boolean](
+    setup = test => (x: Int, y: Int) => x < y,
+    teardown = suite => ()
+  )
+
+  val instanceExamplesAndComparisonFunction = FunFixture.map2(
+    FunFixture.map3(instance, exampleOne, exampleTwo),
+    comparisonFunction
+  )
+
+  val logName =
+    FunFixture[String](setup = test => "logName", teardown = suite => ())
+
+  val instanceLogNameExamplesAndComparisonFunction =
+    FunFixture.map2(instanceExamplesAndComparisonFunction, logName)
+
+  val cond = FunFixture[Boolean](setup = test => true, teardown = suite => ())
+
+  val failCond =
+    FunFixture[Boolean](setup = test => false, teardown = suite => ())
+
+  val clue = FunFixture[String](setup = test => "clue", teardown = suite => ())
+
+  val instanceConditionAndClue = FunFixture.map3(instance, cond, clue)
+
+  val instanceConditionClueAndSuccess =
+    FunFixture.map2(instanceConditionAndClue, resultSuccess)
+
+  val failException = FunFixture[Exception](
+    setup = test => new Exception("fail!"),
+    teardown = suite => ()
+  )
+
+  val instanceAndSuccess = FunFixture.map2(instance, resultSuccess)
+
+  val instanceAndFailException = FunFixture.map2(instance, failException)
+
+  val log = FunFixture[Log](
+    setup = test => Log.String2Log("woot"),
+    teardown = suite => ()
+  )
+
+  val instanceAndLog = FunFixture.map2(instance, log)
+
+  val instanceConditionAndSuccess =
+    FunFixture.map3(instance, cond, resultSuccess)
+
+  val instanceConditionAndFailure =
+    FunFixture.map3(instance, failCond, resultFailure)
+
+  val instanceAndExample1AndClueAndSuccess =
+    FunFixture.map2(FunFixture.map3(instance, exampleOne, clue), resultSuccess)
+
+  val failResult = FunFixture[Result](
+    setup = test =>
+      Result.failure
+        .log("=== Failed ===")
+        .log("--- lhs ---")
+        .log("1")
+        .log("--- rhs ---")
+        .log("2"),
+    teardown = suite => ()
+  )
+
+  val instanceExamplesAndClueAndFailureExamples =
+    FunFixture.map3(
+      FunFixture.map3(instance, exampleOne, exampleTwo),
+      clue,
+      failResult
+    )
+
+  val instanceExamplesAndSuccess =
+    FunFixture.map3(instance, exampleOne, resultSuccess)
+
+  val instanceExamplesAndFailure = FunFixture.map2(
+    FunFixture.map3(instance, exampleOne, exampleTwo),
+    failResult
+  )
+
+  val doubleExample =
+    FunFixture[Double](setup = testOptions => 1.00, teardown = _ => ())
+
+  val doubleExample2 =
+    FunFixture[Double](setup = testOptions => 2.00, teardown = _ => ())
+
+  val doubleExample3 =
+    FunFixture[Double](setup = testOptions => 3.00, teardown = _ => ())
+
+  val instanceDoubleExampleClueAndSuccess = FunFixture.map2(
+    FunFixture.map3(instance, doubleExample, clue),
+    resultSuccess
+  )
+
+  val deltaDouble =
+    FunFixture[Double](setup = testOptions => 1.00, teardown = _ => ())
+
+  val instanceDoubleExamplesDeltaClueAndSuccess = FunFixture.map2(
+    FunFixture.map3(
+      FunFixture.map3(instance, doubleExample, doubleExample2),
+      deltaDouble,
+      clue
+    ),
+    resultSuccess
+  )
+
+  val resultDeltaFailure = FunFixture[Result](
+    setup = testOptions => {
+      Result.failure
+        .log("=== Failed ===")
+        .log("--- lhs ---")
+        .log("1")
+        .log("--- rhs ---")
+        .log("3")
+    },
+    teardown = _ => ()
+  )
+
+  val instanceDoubleExamplesDeltaClueAndFailure = FunFixture.map2(
+    FunFixture.map3(
+      FunFixture.map3(instance, doubleExample, doubleExample3),
+      deltaDouble,
+      clue
+    ),
+    resultDeltaFailure
+  )
+
+  val instanceDoubleExamplesDeltaAndSuccess = FunFixture.map3(
+    FunFixture.map3(instance, doubleExample, doubleExample2),
+    deltaDouble,
+    resultSuccess
+  )
+
+  val instanceDoubleExamplesDeltaAndFailure = FunFixture.map3(
+    FunFixture.map3(instance, doubleExample, doubleExample3),
+    deltaDouble,
+    resultDeltaFailure
+  )
+
+  val floatExample = FunFixture[Float](setup = _ => 1.0f, teardown = _ => ())
+  val floatExample2 = FunFixture[Float](setup = _ => 2.0f, teardown = _ => ())
+  val floatDelta = FunFixture[Float](setup = _ => 1.0f, teardown = _ => ())
+  val instanceFloatExamplesDeltaClueAndSuccess = FunFixture.map2(
+    FunFixture.map3(
+      FunFixture.map3(instance, floatExample, floatExample2),
+      floatDelta,
+      clue
+    ),
+    resultSuccess
+  )
+
+  val floatExample3 = FunFixture[Float](setup = _ => 3.0f, teardown = _ => ())
+
+  val instanceFloatExamplesDeltaClueAndFailure = FunFixture.map2(
+    FunFixture.map3(
+      FunFixture.map3(instance, floatExample, floatExample3),
+      floatDelta,
+      clue
+    ),
+    resultDeltaFailure
+  )
+
+  val instanceFloatExamplesDeltaAndSuccess = FunFixture.map3(
+    FunFixture.map3(instance, floatExample, floatExample2),
+    floatDelta,
+    resultSuccess
+  )
+
+  val instanceFloatExamplesDeltaAndFailure = FunFixture.map3(
+    FunFixture.map3(instance, floatExample, floatExample3),
+    floatDelta,
+    resultDeltaFailure
+  )
+
+  val exampleStr =
+    FunFixture[String](setup = _ => "example", teardown = _ => ())
+
+  val instanceExampleClueAndSuccess =
+    FunFixture.map2(FunFixture.map3(instance, exampleStr, clue), resultSuccess)
+
+  val exampleStr2 =
+    FunFixture[String](setup = _ => "example2", teardown = _ => ())
+
+  val instanceExamplesClueAndFailure = FunFixture.map3(
+    FunFixture.map3(instance, exampleStr, exampleStr2),
+    clue,
+    resultFailure
+  )
+
+  val instanceExampleAndSuccess =
+    FunFixture.map3(instance, exampleStr, resultSuccess)
+
+  val instanceExampleStringsAndFailure = FunFixture.map2(
+    FunFixture.map3(instance, exampleStr, exampleStr2),
+    resultFailure
+  )
+
+  val instanceNonequalExamplesClueAndSuccess = FunFixture.map3(
+    FunFixture.map3(instance, exampleStr, exampleStr2),
+    clue,
+    resultSuccess
+  )
+
+  val resultStringFailure = FunFixture[Result](
+    setup = _ =>
+      Result.failure
+        .log("=== Failed ===")
+        .log("--- lhs ---")
+        .log("example")
+        .log("--- rhs ---")
+        .log("example"),
+    teardown = _ => ()
+  )
+
+  val instanceExampleClueAndFailure = FunFixture.map2(
+    FunFixture.map3(instance, exampleStr, clue),
+    resultStringFailure
+  )
+
+  val instanceNonequalExamplesAndSuccess = FunFixture.map2(
+    FunFixture.map3(instance, exampleStr, exampleStr2),
+    resultSuccess
+  )
+
+  val resultStringEqualFailure = FunFixture[Result](
+    setup = _ =>
+      Result.failure
+        .log("=== Failed ===")
+        .log("--- lhs ---")
+        .log("example")
+        .log("--- rhs ---")
+        .log("example"),
+    teardown = _ => ()
+  )
+
+  val instanceExampleStringAndFailure =
+    FunFixture.map3(instance, exampleStr, resultStringEqualFailure)
+
+  val failureThrowable = FunFixture[Throwable](
+    setup = _ => new Exception("Expected"),
+    teardown = _ => ()
+  )
+
+  val resultFailCauseFailure = FunFixture[Result](
+    setup =
+      _ => Result.error(new Exception("example", new Exception("Expected"))),
+    teardown = _ => ()
+  )
+
+  val instanceMessageCauseAndFailure = FunFixture.map2(
+    FunFixture.map3(instance, exampleStr, failureThrowable),
+    resultFailCauseFailure
+  )
+
+  val resultFail = FunFixture[Result](
+    setup = _ => Result.error(new Exception("example")),
+    teardown = _ => ()
+  )
+
+  val instanceMessageAndFailure =
+    FunFixture.map3(instance, exampleStr, resultFail)
+
+  instance.test(
+    "withMunitAssertions passed assertions.assert should be munit.Assertions.assert"
+  ) { hedgehogAssertions =>
+    hedgehogAssertions.withMunitAssertions { assertions =>
+      assertNoDiff(
+        compileErrors("val x: Result = assertions.assert(true)"),
+        """|error:
+        |type mismatch;
+        | found   : Unit
+        | required: hedgehog.Result
+        |    (which expands to)  hedgehog.core.Result
+        |val x: Result = assertions.assert(true)
+        |                                 ^
+        |""".stripMargin
+      )
+    }
+  }
+
+  instance.test(
+    "withMunitAssertions passed assertions.assertEquals should be munit.Assert.assertEquals"
+  ) { hedgehogAssertions =>
+    hedgehogAssertions.withMunitAssertions { assertions =>
+      assertNoDiff(
+        compileErrors("val x: Result = assertions.assertEquals(true, true)"),
+        """|error:
+       |type mismatch;
+       | found   : Unit
+       | required: hedgehog.Result
+       |    (which expands to)  hedgehog.core.Result
+       |val x: Result = assertions.assertEquals(true, true)
+       |                                       ^
+       |""".stripMargin
+      )
+    }
+  }
+
+  instance.test(
+    "withMunitAssertions passed assertions.assertNoDiff should be munit.Assert.assertNoDiff"
+  )(hedgehogAssertions =>
+    hedgehogAssertions.withMunitAssertions { assertions =>
+      assertNoDiff(
+        compileErrors(
+          "val x: Result = assertions.assertNoDiff(\"true\", \"true\")"
+        ),
+        """|error:
+       |type mismatch;
+       | found   : Unit
+       | required: hedgehog.Result
+       |    (which expands to)  hedgehog.core.Result
+       |val x: Result = assertions.assertNoDiff("true", "true")
+       |                                       ^
+       |""".stripMargin
+      )
+    }
+  )
+
+  instance.test(
+    "withMunitAssertions passed assertions.assertNotEquals should be munit.Assert.assertNotEquals"
+  )(hedgehogAssertions =>
+    hedgehogAssertions.withMunitAssertions { assertions =>
+      assertNoDiff(
+        compileErrors(
+          "val x: Result = assertions.assertNotEquals(true, false)"
+        ),
+        """|error:
+       |type mismatch;
+       | found   : Unit
+       | required: hedgehog.Result
+       |    (which expands to)  hedgehog.core.Result
+       |val x: Result = assertions.assertNotEquals(true, false)
+       |                                          ^
+       |""".stripMargin
+      )
+    }
+  )
+
+  instance.test(
+    "withMunitAssertions passed assertions.assertEqualsDouble should be munit.Assert.assertEqualsDouble"
+  )(hedgehogAssertions =>
+    hedgehogAssertions.withMunitAssertions(assertions =>
+      assertNoDiff(
+        compileErrors(
+          "val x: Result = assertions.assertEqualsDouble(0.00, 0.00, 0.00)"
+        ),
+        """|error:
+       |type mismatch;
+       | found   : Unit
+       | required: hedgehog.Result
+       |    (which expands to)  hedgehog.core.Result
+       |val x: Result = assertions.assertEqualsDouble(0.00, 0.00, 0.00)
+       |                                             ^
+       |""".stripMargin
+      )
+    )
+  )
+
+  instance.test(
+    "withMunitAssertions passed assertions.assertEqualsFloat should be munit.Assert.assertEqualsFloat"
+  )(hedgehogAssertions =>
+    hedgehogAssertions.withMunitAssertions(assertions =>
+      assertNoDiff(
+        compileErrors(
+          "val x: Result = assertions.assertEqualsFloat(0.0f, 0.0f, 0.0f)"
+        ),
+        """|error:
+       |type mismatch;
+       | found   : Unit
+       | required: hedgehog.Result
+       |    (which expands to)  hedgehog.core.Result
+       |val x: Result = assertions.assertEqualsFloat(0.0f, 0.0f, 0.0f)
+       |                                            ^
+       |""".stripMargin
+      )
+    )
+  )
+
+  instance.test(
+    "withMunitAssertions passed assertions.fail should be munit.Assert.fail"
+  )(hedgehogAssertions =>
+    hedgehogAssertions.withMunitAssertions(assertions =>
+      assertNoDiff(
+        compileErrors(
+          "val x: Result = try{assertions.fail(\"this test should fail\")} catch { case e: Throwable => () }"
+        ),
+        """|error:
+       |type mismatch;
+       | found   : Unit
+       | required: hedgehog.Result
+       |    (which expands to)  hedgehog.core.Result
+       |val x: Result = try{assertions.fail("this test should fail")} catch { case e: Throwable => () }
+       |                                                                                           ^
+       |""".stripMargin
+      )
+    )
+  )
+
+  instance.test(
+    "withMunitAssertions passed assertions.fail(message, throwable) should be munit.Assert.fail(message, throwable)"
+  )(hedgehogAssertions =>
+    hedgehogAssertions.withMunitAssertions(assertions =>
+      assertNoDiff(
+        compileErrors(
+          "val x: Result = try{assertions.fail(\"this test should fail\", new Exception(\"fail!\"))} catch { case e: Throwable => () }"
+        ),
+        """|error:
+       |type mismatch;
+       | found   : Unit
+       | required: hedgehog.Result
+       |    (which expands to)  hedgehog.core.Result
+       |val x: Result = try{assertions.fail("this test should fail", new Exception("fail!"))} catch { case e: Throwable => () }
+       |                                                                                                                   ^
+       |""".stripMargin
+      )
+    )
+  )
+
+  instance.test(
+    "type Failure should be Result.Falure"
+  )(hedgehogAssertions =>
+    assertNoDiff(
+      compileErrors(
+        "val x: hedgehogAssertions.Failure = Result.Success"
+      ),
+      """|error:
+       |type mismatch;
+       | found   : hedgehog.Result.Success.type
+       | required: hedgehogAssertions.Failure
+       |    (which expands to)  hedgehog.Result.Failure
+       |val x: hedgehogAssertions.Failure = Result.Success
+       |                                           ^
+       |""".stripMargin
+    )
+  )
+
+  instance.test(
+    "type Success should be Result.Success"
+  )(hedgehogAssertions =>
+    assertNoDiff(
+      compileErrors(
+        "val x: hedgehogAssertions.Success = Result.Failure(List.empty[Log])"
+      ),
+      """|error:
+       |type mismatch;
+       | found   : hedgehog.Result.Failure
+       | required: hedgehogAssertions.Success
+       |    (which expands to)  hedgehog.Result.Success.type
+       |val x: hedgehogAssertions.Success = Result.Failure(List.empty[Log])
+       |                                                  ^
+       |""".stripMargin
+    )
+  )
+
+  instance.test("Success should be Result.Success") { hedgehogAssertions =>
+    assertEquals(hedgehogAssertions.Success, Result.Success)
+  }
+
+  instanceAndLog.test("Failure(log) should output a Result.Failure") {
+    case (hedgehogAssertions, resultLog) =>
+      assertEquals(
+        hedgehogAssertions.Failure(List(resultLog)),
+        Result.Failure(List(resultLog))
+      )
+  }
+
+  instance.test("success should be Result.success") { hedgehogAssertions =>
+    assertEquals(hedgehogAssertions.success, Result.success)
+  }
+
+  instance.test("failure should be Result.failure") { hedgehogAssertions =>
+    assertEquals(hedgehogAssertions.failure, Result.failure)
+  }
+
+  instanceAndFailException.test(
+    "error(exception) should be Result.error(exception)"
+  ) { case (hedgehogAssertions, exception) =>
+    assertEquals(hedgehogAssertions.error(exception), Result.error(exception))
+  }
+
+  instanceAndSuccess.test("all(results) should be Result.all(results)") {
+    case (hedgehogAssertions, successResult) =>
+      val results = List(successResult, successResult)
+      assertEquals(hedgehogAssertions.all(results), Result.all(results))
+  }
+
+  instanceAndResults.test("any(results) should be Result.any(reults)") {
+    case (hedgehogAssertions, successResult, failureResult) =>
+      val results = List(successResult, failureResult)
+      assertEquals(hedgehogAssertions.any(results), Result.any(results))
+  }
+
+  instanceExamplesAndComparisonFunction.test(
+    "diff(a, b)(comparison) should be Result.diff(a, b)(comparison)"
+  ) { case ((hedgehogAssertions, a, b), comparison) =>
+    assertEquals(
+      hedgehogAssertions.diff(a, b)(comparison),
+      Result.diff(a, b)(comparison)
+    )
+  }
+
+  instanceLogNameExamplesAndComparisonFunction.test(
+    "diffNamed(logName, a, b)(comparison) should be Result.diffNamed(logName, a, b)(comparison)"
+  ) { case ((((hedgehogAssertions, a, b), comparison), logName)) =>
+    assertEquals(
+      hedgehogAssertions.diffNamed(logName, a, b)(comparison),
+      Result.diffNamed(logName, a, b)(comparison)
+    )
+  }
+
+  instanceConditionClueAndSuccess.test(
+    "assert(true, clue) should be Result.Success"
+  ) { case ((hedgehogAssertions, condition, clue), resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assert(condition, clue),
+      resultSuccess
+    )
+  }
+
+  instanceConditionAndSuccess.test(
+    "assert(true) should be Result.Success"
+  ) { case (hedgehogAssertions, condition, success) =>
+    assertEquals(hedgehogAssertions.assert(condition), success)
+  }
+
+  instanceConditionAndFailure.test(
+    "assert(false) should be Result.Failure"
+  ) { case (hedgehogAssertions, failCond, failResult) =>
+    assertEquals(hedgehogAssertions.assert(failCond), failResult)
+  }
+
+  instanceAndExample1AndClueAndSuccess.test(
+    "assertEquals(example, example, clue) should be Result.success"
+  ) { case ((hedgehogAssertions, example, clue), success) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example, example, clue),
+      success
+    )
+  }
+
+  instanceExamplesAndClueAndFailureExamples.test(
+    "assertEquals(example1, example2, clue) should be Result.failure with a difference log"
+  ) { case ((hedgehogAssertions, example1, example2), clue, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example1, example2, clue),
+      resultFailure
+    )
+  }
+
+  instanceExamplesAndSuccess.test(
+    "assertEquals(example, example, clue), should be Success"
+  ) { case (hedgehogAssertions, example, resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example, example),
+      resultSuccess
+    )
+
+  }
+
+  instanceExamplesAndFailure.test(
+    "assertEquals(example1, example2) should be a Result.Failure with a log"
+  ) { case ((hedgehogAssertions, example1, example2), resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example1, example2),
+      resultFailure
+    )
+  }
+
+  instanceDoubleExampleClueAndSuccess.test(
+    "assertEqualsDouble(example, example, 0.00, clue), should be Success"
+  ) { case ((hedgehogAssertions, example, clue), resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example, example, 0.00),
+      resultSuccess
+    )
+  }
+
+  instanceDoubleExamplesDeltaClueAndSuccess.test(
+    "assertEqualsDouble(example1, example2, delta, clue) should be Success"
+  ) {
+    case (
+          ((hedgehogAssertions, example1, example2), delta, clue),
+          resultSuccess
+        ) =>
+      assertEquals(
+        hedgehogAssertions.assertEqualsDouble(example1, example2, delta, clue),
+        resultSuccess
+      )
+  }
+
+  instanceDoubleExamplesDeltaClueAndFailure.test(
+    "assertEqualsDouble(example1, example3, delta, clue) should be a failure with a diff log"
+  ) {
+    case (
+          ((hedgehogAssertions, example1, example2), delta, clue),
+          resultFailure
+        ) =>
+      assertEquals(
+        hedgehogAssertions.assertEqualsDouble(example1, example2, delta, clue),
+        resultFailure
+      )
+  }
+
+  instanceDoubleExamplesDeltaAndSuccess.test(
+    "diffDouble(example1, example2, delta) should be Success"
+  ) { case ((hedgehogAssertions, example1, example2), delta, resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.diffDouble(example1, example2, delta),
+      resultSuccess
+    )
+  }
+
+  instanceDoubleExamplesDeltaAndFailure.test(
+    "diffDouble(example1, example3, delta) should be Result.Failure with a diff log"
+  ) { case ((hedgehogAssertions, example1, example3), delta, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.diffDouble(example1, example3, delta),
+      resultFailure
+    )
+  }
+
+  instanceFloatExamplesDeltaClueAndSuccess.test(
+    "assertEqualsFloat(example1, example2, delta, clue) should be Success"
+  ) {
+    case (
+          ((hedgehogAssertions, example1, example2), delta, clue),
+          resultSuccess
+        ) =>
+      assertEquals(
+        hedgehogAssertions.assertEqualsFloat(example1, example2, delta, clue),
+        resultSuccess
+      )
+  }
+
+  instanceFloatExamplesDeltaClueAndFailure.test(
+    "assertEqualsFloat(example1, example3, delta, clue) should be Result.Failure with a diff log"
+  ) {
+    case (
+          ((hedgehogAssertions, example1, example3), delta, clue),
+          resultFailure
+        ) =>
+      assertEquals(
+        hedgehogAssertions.assertEqualsFloat(example1, example3, delta, clue),
+        resultFailure
+      )
+  }
+
+  instanceFloatExamplesDeltaAndSuccess.test(
+    "diffFloat(example1, example2, delta) should be Success"
+  ) { case ((hedgehogAssertions, example1, example2), delta, resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.diffFloat(example1, example2, delta),
+      resultSuccess
+    )
+  }
+
+  instanceFloatExamplesDeltaAndFailure.test(
+    "diffFloat(example1, example3, delta) should be Result.Failure with a diff log"
+  ) { case ((hedgehogAssertions, example1, example3), delta, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.diffFloat(example1, example3, delta),
+      resultFailure
+    )
+  }
+
+  instanceExampleClueAndSuccess.test(
+    "assertNoDiff(str, str, clue) should be Result.success"
+  ) { case ((hedgehogAssertions, str, clue), resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assertNoDiff(str, str, clue),
+      resultSuccess
+    )
+  }
+
+  instanceExamplesClueAndFailure.test(
+    "assertNoDiff(str, str2, clue) should be Result.failure"
+  ) { case ((hedgehogAssertions, str, str2), clue, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.assertNoDiff(str, str2, clue),
+      resultFailure
+    )
+  }
+
+  instanceExampleAndSuccess.test("assertNoDiff(str, str) should be Success") {
+    case (hedgehogAssertions, str, resultSuccess) =>
+      assertEquals(hedgehogAssertions.assertNoDiff(str, str), resultSuccess)
+  }
+
+  instanceExampleStringsAndFailure.test(
+    "assertNoDiff(str, str2) should be Result.failure"
+  ) { case ((hedgehogAssertions, str, str2), resultFailure) =>
+    assertEquals(hedgehogAssertions.assertNoDiff(str, str2), resultFailure)
+  }
+
+  instanceNonequalExamplesClueAndSuccess.test(
+    "assertNotEquals(str, str2, clue) should be Success"
+  ) { case ((hedgehogAssertions, str, str2), clue, resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assertNotEquals(str, str2, clue),
+      resultSuccess
+    )
+  }
+
+  instanceExampleClueAndFailure.test(
+    "assertNotEquals(str, str, clue) should be Result.failure with a diff log"
+  ) { case ((hedgehogAssertions, str, clue), resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.assertNotEquals(str, str, clue),
+      resultFailure
+    )
+  }
+
+  instanceNonequalExamplesAndSuccess.test(
+    "assertEquals(str, str2) should be Success"
+  ) { case ((hedgehogAssertions, str, str2), resultSucces) =>
+    assertEquals(hedgehogAssertions.assertNotEquals(str, str2), resultSucces)
+  }
+
+  instanceExampleStringAndFailure.test(
+    "assertEquals(str, str) should be resultFailure with a diff log"
+  ) { case (hedgehogAssertions, str, resultFailure) =>
+    assertEquals(hedgehogAssertions.assertNotEquals(str, str), resultFailure)
+  }
+
+  instanceMessageCauseAndFailure.test(
+    "fail(message, cause) should be a Result.failure with a message and cause log"
+  ) { case ((hedgehogAssertions, message, cause), resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.fail(message, cause).toString(),
+      resultFailure.toString()
+    )
+  }
+
+  instanceMessageAndFailure.test(
+    "fail(message) should be a Result.failure with a message"
+  ) { case (hedgehogAssertions, message, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.fail(message).toString(),
+      resultFailure.toString()
+    )
+  }
+}

--- a/munit/js/src/test/scala-2/hedgehog/munit/HedgehogSuiteIntegrationTest.scala
+++ b/munit/js/src/test/scala-2/hedgehog/munit/HedgehogSuiteIntegrationTest.scala
@@ -1,0 +1,48 @@
+package hedgehog
+package munit
+
+class HedgehogSuiteIntegrationTest extends HedgehogSuite {
+
+  lazy val intGen = Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).forAll
+
+  property("`property` works just like `test`, when it passes, it passes.") {
+    for {
+      x <- intGen
+    } yield Result.diff(x, x + 0)(_ == _)
+  }
+
+  property("`Result.type` members are directly available for use") {
+    for {
+      x <- intGen
+    } yield diff(x, x + 0)(_ == _)
+  }
+
+  property("`property` tests accept munit Assertions-like `assert*` results") {
+    for {
+      x <- intGen
+    } yield assertEquals(clue(x), clue(x + 0))
+
+  }
+
+  // uncomment to see compilation errors related to deprecation encouraging
+  // non-clue diff and diff delegating assertions
+  // property("passing clues explicitly will cause a deprecation warning for any munit-like assertions in HedgehogAssertions"){
+  //   for{
+  //     x <- intGen
+  //   } yield assertEquals(x, 2, clues(clue(x), clue(2)))
+  // }
+
+  // uncomment to see what HedgehogAssertions munit-like assert* test reports
+  // look like
+  // property("doing what the above deprecation says to do will result in a nice clue-like diff with a minimal failing example, hedgehog-style"){
+  //   for{
+  //     x <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).forAll
+  //   } yield assertEquals(x, 2)
+  // }
+
+  test(
+    "regular unit returning munit assertions work just fine, you just have to turn off the hedgehog assertions."
+  ) {
+    withMunitAssertions(assertions => assertions.assertEquals(1, 1))
+  }
+}

--- a/munit/js/src/test/scala-3/hedgehog/munit/HedgehogAssertionsSuite.scala
+++ b/munit/js/src/test/scala-3/hedgehog/munit/HedgehogAssertionsSuite.scala
@@ -1,0 +1,580 @@
+package hedgehog
+package munit
+
+import hedgehog.core.Log
+import _root_.munit.Assertions
+import _root_.munit.FunSuite
+
+class HedgehogAssertionsSuite extends FunSuite {
+
+  val instance = FunFixture[HedgehogAssertions](
+    setup = { test =>
+      new HedgehogAssertions with Assertions {}
+    },
+    teardown = { suite => () }
+  )
+
+  val resultSuccess =
+    FunFixture[Result](setup = test => Result.success, teardown = suite => ())
+
+  val resultFailure =
+    FunFixture[Result](setup = test => Result.failure, teardown = suite => ())
+
+  val results = FunFixture.map2(resultSuccess, resultFailure)
+
+  val instanceAndResults =
+    FunFixture.map3(instance, resultSuccess, resultFailure)
+
+  val exampleOne = FunFixture[Int](setup = test => 1, teardown = suite => ())
+
+  val exampleTwo = FunFixture[Int](setup = test => 2, teardown = suite => ())
+
+  val comparisonFunction = FunFixture[(Int, Int) => Boolean](
+    setup = test => (x: Int, y: Int) => x < y,
+    teardown = suite => ()
+  )
+
+  val instanceExamplesAndComparisonFunction = FunFixture.map2(
+    FunFixture.map3(instance, exampleOne, exampleTwo),
+    comparisonFunction
+  )
+
+  val logName =
+    FunFixture[String](setup = test => "logName", teardown = suite => ())
+
+  val instanceLogNameExamplesAndComparisonFunction =
+    FunFixture.map2(instanceExamplesAndComparisonFunction, logName)
+
+  val cond = FunFixture[Boolean](setup = test => true, teardown = suite => ())
+
+  val failCond =
+    FunFixture[Boolean](setup = test => false, teardown = suite => ())
+
+  val clue = FunFixture[String](setup = test => "clue", teardown = suite => ())
+
+  val instanceConditionAndClue = FunFixture.map3(instance, cond, clue)
+
+  val instanceConditionClueAndSuccess =
+    FunFixture.map2(instanceConditionAndClue, resultSuccess)
+
+  val failException = FunFixture[Exception](
+    setup = test => new Exception("fail!"),
+    teardown = suite => ()
+  )
+
+  val instanceAndSuccess = FunFixture.map2(instance, resultSuccess)
+
+  val instanceAndFailException = FunFixture.map2(instance, failException)
+
+  val log = FunFixture[Log](
+    setup = test => Log.String2Log("woot"),
+    teardown = suite => ()
+  )
+
+  val instanceAndLog = FunFixture.map2(instance, log)
+
+  val instanceConditionAndSuccess =
+    FunFixture.map3(instance, cond, resultSuccess)
+
+  val instanceConditionAndFailure =
+    FunFixture.map3(instance, failCond, resultFailure)
+
+  val instanceAndExample1AndClueAndSuccess =
+    FunFixture.map2(FunFixture.map3(instance, exampleOne, clue), resultSuccess)
+
+  val failResult = FunFixture[Result](
+    setup = test =>
+      Result.failure
+        .log("=== Failed ===")
+        .log("--- lhs ---")
+        .log("1")
+        .log("--- rhs ---")
+        .log("2"),
+    teardown = suite => ()
+  )
+
+  val instanceExamplesAndClueAndFailureExamples =
+    FunFixture.map3(
+      FunFixture.map3(instance, exampleOne, exampleTwo),
+      clue,
+      failResult
+    )
+
+  val instanceExamplesAndSuccess =
+    FunFixture.map3(instance, exampleOne, resultSuccess)
+
+  val instanceExamplesAndFailure = FunFixture.map2(
+    FunFixture.map3(instance, exampleOne, exampleTwo),
+    failResult
+  )
+
+  val doubleExample =
+    FunFixture[Double](setup = testOptions => 1.00, teardown = _ => ())
+
+  val doubleExample2 =
+    FunFixture[Double](setup = testOptions => 2.00, teardown = _ => ())
+
+  val doubleExample3 =
+    FunFixture[Double](setup = testOptions => 3.00, teardown = _ => ())
+
+  val instanceDoubleExampleClueAndSuccess = FunFixture.map2(
+    FunFixture.map3(instance, doubleExample, clue),
+    resultSuccess
+  )
+
+  val deltaDouble =
+    FunFixture[Double](setup = testOptions => 1.00, teardown = _ => ())
+
+  val instanceDoubleExamplesDeltaClueAndSuccess = FunFixture.map2(
+    FunFixture.map3(
+      FunFixture.map3(instance, doubleExample, doubleExample2),
+      deltaDouble,
+      clue
+    ),
+    resultSuccess
+  )
+
+  val resultDeltaFailure = FunFixture[Result](
+    setup = testOptions => {
+      Result.failure
+        .log("=== Failed ===")
+        .log("--- lhs ---")
+        .log("1")
+        .log("--- rhs ---")
+        .log("3")
+    },
+    teardown = _ => ()
+  )
+
+  val instanceDoubleExamplesDeltaClueAndFailure = FunFixture.map2(
+    FunFixture.map3(
+      FunFixture.map3(instance, doubleExample, doubleExample3),
+      deltaDouble,
+      clue
+    ),
+    resultDeltaFailure
+  )
+
+  val instanceDoubleExamplesDeltaAndSuccess = FunFixture.map3(
+    FunFixture.map3(instance, doubleExample, doubleExample2),
+    deltaDouble,
+    resultSuccess
+  )
+
+  val instanceDoubleExamplesDeltaAndFailure = FunFixture.map3(
+    FunFixture.map3(instance, doubleExample, doubleExample3),
+    deltaDouble,
+    resultDeltaFailure
+  )
+
+  val floatExample = FunFixture[Float](setup = _ => 1.0f, teardown = _ => ())
+  val floatExample2 = FunFixture[Float](setup = _ => 2.0f, teardown = _ => ())
+  val floatDelta = FunFixture[Float](setup = _ => 1.0f, teardown = _ => ())
+  val instanceFloatExamplesDeltaClueAndSuccess = FunFixture.map2(
+    FunFixture.map3(
+      FunFixture.map3(instance, floatExample, floatExample2),
+      floatDelta,
+      clue
+    ),
+    resultSuccess
+  )
+
+  val floatExample3 = FunFixture[Float](setup = _ => 3.0f, teardown = _ => ())
+
+  val instanceFloatExamplesDeltaClueAndFailure = FunFixture.map2(
+    FunFixture.map3(
+      FunFixture.map3(instance, floatExample, floatExample3),
+      floatDelta,
+      clue
+    ),
+    resultDeltaFailure
+  )
+
+  val instanceFloatExamplesDeltaAndSuccess = FunFixture.map3(
+    FunFixture.map3(instance, floatExample, floatExample2),
+    floatDelta,
+    resultSuccess
+  )
+
+  val instanceFloatExamplesDeltaAndFailure = FunFixture.map3(
+    FunFixture.map3(instance, floatExample, floatExample3),
+    floatDelta,
+    resultDeltaFailure
+  )
+
+  val exampleStr =
+    FunFixture[String](setup = _ => "example", teardown = _ => ())
+
+  val instanceExampleClueAndSuccess =
+    FunFixture.map2(FunFixture.map3(instance, exampleStr, clue), resultSuccess)
+
+  val exampleStr2 =
+    FunFixture[String](setup = _ => "example2", teardown = _ => ())
+
+  val instanceExamplesClueAndFailure = FunFixture.map3(
+    FunFixture.map3(instance, exampleStr, exampleStr2),
+    clue,
+    resultFailure
+  )
+
+  val instanceExampleAndSuccess =
+    FunFixture.map3(instance, exampleStr, resultSuccess)
+
+  val instanceExampleStringsAndFailure = FunFixture.map2(
+    FunFixture.map3(instance, exampleStr, exampleStr2),
+    resultFailure
+  )
+
+  val instanceNonequalExamplesClueAndSuccess = FunFixture.map3(
+    FunFixture.map3(instance, exampleStr, exampleStr2),
+    clue,
+    resultSuccess
+  )
+
+  val resultStringFailure = FunFixture[Result](
+    setup = _ =>
+      Result.failure
+        .log("=== Failed ===")
+        .log("--- lhs ---")
+        .log("example")
+        .log("--- rhs ---")
+        .log("example"),
+    teardown = _ => ()
+  )
+
+  val instanceExampleClueAndFailure = FunFixture.map2(
+    FunFixture.map3(instance, exampleStr, clue),
+    resultStringFailure
+  )
+
+  val instanceNonequalExamplesAndSuccess = FunFixture.map2(
+    FunFixture.map3(instance, exampleStr, exampleStr2),
+    resultSuccess
+  )
+
+  val resultStringEqualFailure = FunFixture[Result](
+    setup = _ =>
+      Result.failure
+        .log("=== Failed ===")
+        .log("--- lhs ---")
+        .log("example")
+        .log("--- rhs ---")
+        .log("example"),
+    teardown = _ => ()
+  )
+
+  val instanceExampleStringAndFailure =
+    FunFixture.map3(instance, exampleStr, resultStringEqualFailure)
+
+  val failureThrowable = FunFixture[Throwable](
+    setup = _ => new Exception("Expected"),
+    teardown = _ => ()
+  )
+
+  val resultFailCauseFailure = FunFixture[Result](
+    setup =
+      _ => Result.error(new Exception("example", new Exception("Expected"))),
+    teardown = _ => ()
+  )
+
+  val instanceMessageCauseAndFailure = FunFixture.map2(
+    FunFixture.map3(instance, exampleStr, failureThrowable),
+    resultFailCauseFailure
+  )
+
+  val resultFail = FunFixture[Result](
+    setup = _ => Result.error(new Exception("example")),
+    teardown = _ => ()
+  )
+
+  val instanceMessageAndFailure =
+    FunFixture.map3(instance, exampleStr, resultFail)
+
+  instance.test("Success should be Result.Success") { hedgehogAssertions =>
+    assertEquals(hedgehogAssertions.Success, Result.Success)
+  }
+
+  instanceAndLog.test("Failure(log) should output a Result.Failure") {
+    case (hedgehogAssertions, resultLog) =>
+      assertEquals(
+        hedgehogAssertions.Failure(List(resultLog)),
+        Result.Failure(List(resultLog))
+      )
+  }
+
+  instance.test("success should be Result.success") { hedgehogAssertions =>
+    assertEquals(hedgehogAssertions.success, Result.success)
+  }
+
+  instance.test("failure should be Result.failure") { hedgehogAssertions =>
+    assertEquals(hedgehogAssertions.failure, Result.failure)
+  }
+
+  instanceAndFailException.test(
+    "error(exception) should be Result.error(exception)"
+  ) { case (hedgehogAssertions, exception) =>
+    assertEquals(hedgehogAssertions.error(exception), Result.error(exception))
+  }
+
+  instanceAndSuccess.test("all(results) should be Result.all(results)") {
+    case (hedgehogAssertions, successResult) =>
+      val results = List(successResult, successResult)
+      assertEquals(hedgehogAssertions.all(results), Result.all(results))
+  }
+
+  instanceAndResults.test("any(results) should be Result.any(reults)") {
+    case (hedgehogAssertions, successResult, failureResult) =>
+      val results = List(successResult, failureResult)
+      assertEquals(hedgehogAssertions.any(results), Result.any(results))
+  }
+
+  instanceExamplesAndComparisonFunction.test(
+    "diff(a, b)(comparison) should be Result.diff(a, b)(comparison)"
+  ) { case ((hedgehogAssertions, a, b), comparison) =>
+    assertEquals(
+      hedgehogAssertions.diff(a, b)(comparison),
+      Result.diff(a, b)(comparison)
+    )
+  }
+
+  instanceLogNameExamplesAndComparisonFunction.test(
+    "diffNamed(logName, a, b)(comparison) should be Result.diffNamed(logName, a, b)(comparison)"
+  ) { case ((((hedgehogAssertions, a, b), comparison), logName)) =>
+    assertEquals(
+      hedgehogAssertions.diffNamed(logName, a, b)(comparison),
+      Result.diffNamed(logName, a, b)(comparison)
+    )
+  }
+
+  instanceConditionClueAndSuccess.test(
+    "assert(true, clue) should be Result.Success"
+  ) { case ((hedgehogAssertions, condition, clue), resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assert(condition, clue),
+      resultSuccess
+    )
+  }
+
+  instanceConditionAndSuccess.test(
+    "assert(true) should be Result.Success"
+  ) { case (hedgehogAssertions, condition, success) =>
+    assertEquals(hedgehogAssertions.assert(condition), success)
+  }
+
+  instanceConditionAndFailure.test(
+    "assert(false) should be Result.Failure"
+  ) { case (hedgehogAssertions, failCond, failResult) =>
+    assertEquals(hedgehogAssertions.assert(failCond), failResult)
+  }
+
+  instanceAndExample1AndClueAndSuccess.test(
+    "assertEquals(example, example, clue) should be Result.success"
+  ) { case ((hedgehogAssertions, example, clue), success) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example, example, clue),
+      success
+    )
+  }
+
+  instanceExamplesAndClueAndFailureExamples.test(
+    "assertEquals(example1, example2, clue) should be Result.failure with a difference log"
+  ) { case ((hedgehogAssertions, example1, example2), clue, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example1, example2, clue),
+      resultFailure
+    )
+  }
+
+  instanceExamplesAndSuccess.test(
+    "assertEquals(example, example, clue), should be Success"
+  ) { case (hedgehogAssertions, example, resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example, example),
+      resultSuccess
+    )
+
+  }
+
+  instanceExamplesAndFailure.test(
+    "assertEquals(example1, example2) should be a Result.Failure with a log"
+  ) { case ((hedgehogAssertions, example1, example2), resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example1, example2),
+      resultFailure
+    )
+  }
+
+  instanceDoubleExampleClueAndSuccess.test(
+    "assertEqualsDouble(example, example, 0.00, clue), should be Success"
+  ) { case ((hedgehogAssertions, example, clue), resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example, example, 0.00),
+      resultSuccess
+    )
+  }
+
+  instanceDoubleExamplesDeltaClueAndSuccess.test(
+    "assertEqualsDouble(example1, example2, delta, clue) should be Success"
+  ) {
+    case (
+          ((hedgehogAssertions, example1, example2), delta, clue),
+          resultSuccess
+        ) =>
+      assertEquals(
+        hedgehogAssertions.assertEqualsDouble(example1, example2, delta, clue),
+        resultSuccess
+      )
+  }
+
+  instanceDoubleExamplesDeltaClueAndFailure.test(
+    "assertEqualsDouble(example1, example3, delta, clue) should be a failure with a diff log"
+  ) {
+    case (
+          ((hedgehogAssertions, example1, example2), delta, clue),
+          resultFailure
+        ) =>
+      assertEquals(
+        hedgehogAssertions.assertEqualsDouble(example1, example2, delta, clue),
+        resultFailure
+      )
+  }
+
+  instanceDoubleExamplesDeltaAndSuccess.test(
+    "diffDouble(example1, example2, delta) should be Success"
+  ) { case ((hedgehogAssertions, example1, example2), delta, resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.diffDouble(example1, example2, delta),
+      resultSuccess
+    )
+  }
+
+  instanceDoubleExamplesDeltaAndFailure.test(
+    "diffDouble(example1, example3, delta) should be Result.Failure with a diff log"
+  ) { case ((hedgehogAssertions, example1, example3), delta, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.diffDouble(example1, example3, delta),
+      resultFailure
+    )
+  }
+
+  instanceFloatExamplesDeltaClueAndSuccess.test(
+    "assertEqualsFloat(example1, example2, delta, clue) should be Success"
+  ) {
+    case (
+          ((hedgehogAssertions, example1, example2), delta, clue),
+          resultSuccess
+        ) =>
+      assertEquals(
+        hedgehogAssertions.assertEqualsFloat(example1, example2, delta, clue),
+        resultSuccess
+      )
+  }
+
+  instanceFloatExamplesDeltaClueAndFailure.test(
+    "assertEqualsFloat(example1, example3, delta, clue) should be Result.Failure with a diff log"
+  ) {
+    case (
+          ((hedgehogAssertions, example1, example3), delta, clue),
+          resultFailure
+        ) =>
+      assertEquals(
+        hedgehogAssertions.assertEqualsFloat(example1, example3, delta, clue),
+        resultFailure
+      )
+  }
+
+  instanceFloatExamplesDeltaAndSuccess.test(
+    "diffFloat(example1, example2, delta) should be Success"
+  ) { case ((hedgehogAssertions, example1, example2), delta, resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.diffFloat(example1, example2, delta),
+      resultSuccess
+    )
+  }
+
+  instanceFloatExamplesDeltaAndFailure.test(
+    "diffFloat(example1, example3, delta) should be Result.Failure with a diff log"
+  ) { case ((hedgehogAssertions, example1, example3), delta, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.diffFloat(example1, example3, delta),
+      resultFailure
+    )
+  }
+
+  instanceExampleClueAndSuccess.test(
+    "assertNoDiff(str, str, clue) should be Result.success"
+  ) { case ((hedgehogAssertions, str, clue), resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assertNoDiff(str, str, clue),
+      resultSuccess
+    )
+  }
+
+  instanceExamplesClueAndFailure.test(
+    "assertNoDiff(str, str2, clue) should be Result.failure"
+  ) { case ((hedgehogAssertions, str, str2), clue, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.assertNoDiff(str, str2, clue),
+      resultFailure
+    )
+  }
+
+  instanceExampleAndSuccess.test("assertNoDiff(str, str) should be Success") {
+    case (hedgehogAssertions, str, resultSuccess) =>
+      assertEquals(hedgehogAssertions.assertNoDiff(str, str), resultSuccess)
+  }
+
+  instanceExampleStringsAndFailure.test(
+    "assertNoDiff(str, str2) should be Result.failure"
+  ) { case ((hedgehogAssertions, str, str2), resultFailure) =>
+    assertEquals(hedgehogAssertions.assertNoDiff(str, str2), resultFailure)
+  }
+
+  instanceNonequalExamplesClueAndSuccess.test(
+    "assertNotEquals(str, str2, clue) should be Success"
+  ) { case ((hedgehogAssertions, str, str2), clue, resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assertNotEquals(str, str2, clue),
+      resultSuccess
+    )
+  }
+
+  instanceExampleClueAndFailure.test(
+    "assertNotEquals(str, str, clue) should be Result.failure with a diff log"
+  ) { case ((hedgehogAssertions, str, clue), resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.assertNotEquals(str, str, clue),
+      resultFailure
+    )
+  }
+
+  instanceNonequalExamplesAndSuccess.test(
+    "assertEquals(str, str2) should be Success"
+  ) { case ((hedgehogAssertions, str, str2), resultSucces) =>
+    assertEquals(hedgehogAssertions.assertNotEquals(str, str2), resultSucces)
+  }
+
+  instanceExampleStringAndFailure.test(
+    "assertEquals(str, str) should be resultFailure with a diff log"
+  ) { case (hedgehogAssertions, str, resultFailure) =>
+    assertEquals(hedgehogAssertions.assertNotEquals(str, str), resultFailure)
+  }
+
+  instanceMessageCauseAndFailure.test(
+    "fail(message, cause) should be a Result.failure with a message and cause log"
+  ) { case ((hedgehogAssertions, message, cause), resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.fail(message, cause).toString(),
+      resultFailure.toString()
+    )
+  }
+
+  instanceMessageAndFailure.test(
+    "fail(message) should be a Result.failure with a message"
+  ) { case (hedgehogAssertions, message, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.fail(message).toString(),
+      resultFailure.toString()
+    )
+  }
+}

--- a/munit/js/src/test/scala-3/hedgehog/munit/HedgehogSuiteIntegrationTest.scala
+++ b/munit/js/src/test/scala-3/hedgehog/munit/HedgehogSuiteIntegrationTest.scala
@@ -1,0 +1,48 @@
+package hedgehog
+package munit
+
+class HedgehogSuiteIntegrationTest extends HedgehogSuite {
+
+  lazy val intGen = Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).forAll
+
+  property("`property` works just like `test`, when it passes, it passes.") {
+    for {
+      x <- intGen
+    } yield Result.diff(x, x + 0)(_ == _)
+  }
+
+  property("`Result.type` members are directly available for use") {
+    for {
+      x <- intGen
+    } yield diff(x, x + 0)(_ == _)
+  }
+
+  property("`property` tests accept munit Assertions-like `assert*` results") {
+    for {
+      x <- intGen
+    } yield assertEquals(clue(x), clue(x + 0))
+
+  }
+
+  // uncomment to see compilation errors related to deprecation encouraging
+  // non-clue diff and diff delegating assertions
+  // property("passing clues explicitly will cause a deprecation warning for any munit-like assertions in HedgehogAssertions"){
+  //   for{
+  //     x <- intGen
+  //   } yield assertEquals(x, 2, clues(clue(x), clue(2)))
+  // }
+
+  // uncomment to see what HedgehogAssertions munit-like assert* test reports
+  // look like
+  // property("doing what the above deprecation says to do will result in a nice clue-like diff with a minimal failing example, hedgehog-style"){
+  //   for{
+  //     x <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).forAll
+  //   } yield assertEquals(x, 2)
+  // }
+
+  test(
+    "regular unit returning munit assertions work just fine, you just have to turn off the hedgehog assertions."
+  ) {
+    withMunitAssertions(assertions => assertions.assertEquals(1, 1))
+  }
+}

--- a/munit/jvm/src/test/scala-2/hedgehog/munit/HedgehogAssertionsSuite.scala
+++ b/munit/jvm/src/test/scala-2/hedgehog/munit/HedgehogAssertionsSuite.scala
@@ -1,0 +1,774 @@
+package hedgehog
+package munit
+
+import hedgehog.core.Log
+import _root_.munit.Assertions
+import _root_.munit.FunSuite
+import scala.annotation.nowarn
+
+@nowarn
+class HedgehogAssertionsSuite extends FunSuite {
+
+  val instance = FunFixture[HedgehogAssertions](
+    setup = { test =>
+      new HedgehogAssertions with Assertions {}
+    },
+    teardown = { suite => () }
+  )
+
+  val resultSuccess =
+    FunFixture[Result](setup = test => Result.success, teardown = suite => ())
+
+  val resultFailure =
+    FunFixture[Result](setup = test => Result.failure, teardown = suite => ())
+
+  val results = FunFixture.map2(resultSuccess, resultFailure)
+
+  val instanceAndResults =
+    FunFixture.map3(instance, resultSuccess, resultFailure)
+
+  val exampleOne = FunFixture[Int](setup = test => 1, teardown = suite => ())
+
+  val exampleTwo = FunFixture[Int](setup = test => 2, teardown = suite => ())
+
+  val comparisonFunction = FunFixture[(Int, Int) => Boolean](
+    setup = test => (x: Int, y: Int) => x < y,
+    teardown = suite => ()
+  )
+
+  val instanceExamplesAndComparisonFunction = FunFixture.map2(
+    FunFixture.map3(instance, exampleOne, exampleTwo),
+    comparisonFunction
+  )
+
+  val logName =
+    FunFixture[String](setup = test => "logName", teardown = suite => ())
+
+  val instanceLogNameExamplesAndComparisonFunction =
+    FunFixture.map2(instanceExamplesAndComparisonFunction, logName)
+
+  val cond = FunFixture[Boolean](setup = test => true, teardown = suite => ())
+
+  val failCond =
+    FunFixture[Boolean](setup = test => false, teardown = suite => ())
+
+  val clue = FunFixture[String](setup = test => "clue", teardown = suite => ())
+
+  val instanceConditionAndClue = FunFixture.map3(instance, cond, clue)
+
+  val instanceConditionClueAndSuccess =
+    FunFixture.map2(instanceConditionAndClue, resultSuccess)
+
+  val failException = FunFixture[Exception](
+    setup = test => new Exception("fail!"),
+    teardown = suite => ()
+  )
+
+  val instanceAndSuccess = FunFixture.map2(instance, resultSuccess)
+
+  val instanceAndFailException = FunFixture.map2(instance, failException)
+
+  val log = FunFixture[Log](
+    setup = test => Log.String2Log("woot"),
+    teardown = suite => ()
+  )
+
+  val instanceAndLog = FunFixture.map2(instance, log)
+
+  val instanceConditionAndSuccess =
+    FunFixture.map3(instance, cond, resultSuccess)
+
+  val instanceConditionAndFailure =
+    FunFixture.map3(instance, failCond, resultFailure)
+
+  val instanceAndExample1AndClueAndSuccess =
+    FunFixture.map2(FunFixture.map3(instance, exampleOne, clue), resultSuccess)
+
+  val failResult = FunFixture[Result](
+    setup = test =>
+      Result.failure
+        .log("=== Failed ===")
+        .log("--- lhs ---")
+        .log("1")
+        .log("--- rhs ---")
+        .log("2"),
+    teardown = suite => ()
+  )
+
+  val instanceExamplesAndClueAndFailureExamples =
+    FunFixture.map3(
+      FunFixture.map3(instance, exampleOne, exampleTwo),
+      clue,
+      failResult
+    )
+
+  val instanceExamplesAndSuccess =
+    FunFixture.map3(instance, exampleOne, resultSuccess)
+
+  val instanceExamplesAndFailure = FunFixture.map2(
+    FunFixture.map3(instance, exampleOne, exampleTwo),
+    failResult
+  )
+
+  val doubleExample =
+    FunFixture[Double](setup = testOptions => 1.00, teardown = _ => ())
+
+  val doubleExample2 =
+    FunFixture[Double](setup = testOptions => 2.00, teardown = _ => ())
+
+  val doubleExample3 =
+    FunFixture[Double](setup = testOptions => 3.00, teardown = _ => ())
+
+  val instanceDoubleExampleClueAndSuccess = FunFixture.map2(
+    FunFixture.map3(instance, doubleExample, clue),
+    resultSuccess
+  )
+
+  val deltaDouble =
+    FunFixture[Double](setup = testOptions => 1.00, teardown = _ => ())
+
+  val instanceDoubleExamplesDeltaClueAndSuccess = FunFixture.map2(
+    FunFixture.map3(
+      FunFixture.map3(instance, doubleExample, doubleExample2),
+      deltaDouble,
+      clue
+    ),
+    resultSuccess
+  )
+
+  val resultDeltaFailure = FunFixture[Result](
+    setup = testOptions => {
+      Result.failure
+        .log("=== Failed ===")
+        .log("--- lhs ---")
+        .log("1.0")
+        .log("--- rhs ---")
+        .log("3.0")
+    },
+    teardown = _ => ()
+  )
+
+  val instanceDoubleExamplesDeltaClueAndFailure = FunFixture.map2(
+    FunFixture.map3(
+      FunFixture.map3(instance, doubleExample, doubleExample3),
+      deltaDouble,
+      clue
+    ),
+    resultDeltaFailure
+  )
+
+  val instanceDoubleExamplesDeltaAndSuccess = FunFixture.map3(
+    FunFixture.map3(instance, doubleExample, doubleExample2),
+    deltaDouble,
+    resultSuccess
+  )
+
+  val instanceDoubleExamplesDeltaAndFailure = FunFixture.map3(
+    FunFixture.map3(instance, doubleExample, doubleExample3),
+    deltaDouble,
+    resultDeltaFailure
+  )
+
+  val floatExample = FunFixture[Float](setup = _ => 1.0f, teardown = _ => ())
+  val floatExample2 = FunFixture[Float](setup = _ => 2.0f, teardown = _ => ())
+  val floatDelta = FunFixture[Float](setup = _ => 1.0f, teardown = _ => ())
+  val instanceFloatExamplesDeltaClueAndSuccess = FunFixture.map2(
+    FunFixture.map3(
+      FunFixture.map3(instance, floatExample, floatExample2),
+      floatDelta,
+      clue
+    ),
+    resultSuccess
+  )
+
+  val floatExample3 = FunFixture[Float](setup = _ => 3.0f, teardown = _ => ())
+
+  val instanceFloatExamplesDeltaClueAndFailure = FunFixture.map2(
+    FunFixture.map3(
+      FunFixture.map3(instance, floatExample, floatExample3),
+      floatDelta,
+      clue
+    ),
+    resultDeltaFailure
+  )
+
+  val instanceFloatExamplesDeltaAndSuccess = FunFixture.map3(
+    FunFixture.map3(instance, floatExample, floatExample2),
+    floatDelta,
+    resultSuccess
+  )
+
+  val instanceFloatExamplesDeltaAndFailure = FunFixture.map3(
+    FunFixture.map3(instance, floatExample, floatExample3),
+    floatDelta,
+    resultDeltaFailure
+  )
+
+  val exampleStr =
+    FunFixture[String](setup = _ => "example", teardown = _ => ())
+
+  val instanceExampleClueAndSuccess =
+    FunFixture.map2(FunFixture.map3(instance, exampleStr, clue), resultSuccess)
+
+  val exampleStr2 =
+    FunFixture[String](setup = _ => "example2", teardown = _ => ())
+
+  val instanceExamplesClueAndFailure = FunFixture.map3(
+    FunFixture.map3(instance, exampleStr, exampleStr2),
+    clue,
+    resultFailure
+  )
+
+  val instanceExampleAndSuccess =
+    FunFixture.map3(instance, exampleStr, resultSuccess)
+
+  val instanceExampleStringsAndFailure = FunFixture.map2(
+    FunFixture.map3(instance, exampleStr, exampleStr2),
+    resultFailure
+  )
+
+  val instanceNonequalExamplesClueAndSuccess = FunFixture.map3(
+    FunFixture.map3(instance, exampleStr, exampleStr2),
+    clue,
+    resultSuccess
+  )
+
+  val resultStringFailure = FunFixture[Result](
+    setup = _ =>
+      Result.failure
+        .log("=== Failed ===")
+        .log("--- lhs ---")
+        .log("example")
+        .log("--- rhs ---")
+        .log("example"),
+    teardown = _ => ()
+  )
+
+  val instanceExampleClueAndFailure = FunFixture.map2(
+    FunFixture.map3(instance, exampleStr, clue),
+    resultStringFailure
+  )
+
+  val instanceNonequalExamplesAndSuccess = FunFixture.map2(
+    FunFixture.map3(instance, exampleStr, exampleStr2),
+    resultSuccess
+  )
+
+  val resultStringEqualFailure = FunFixture[Result](
+    setup = _ =>
+      Result.failure
+        .log("=== Failed ===")
+        .log("--- lhs ---")
+        .log("example")
+        .log("--- rhs ---")
+        .log("example"),
+    teardown = _ => ()
+  )
+
+  val instanceExampleStringAndFailure =
+    FunFixture.map3(instance, exampleStr, resultStringEqualFailure)
+
+  val failureThrowable = FunFixture[Throwable](
+    setup = _ => new Exception("Expected"),
+    teardown = _ => ()
+  )
+
+  val resultFailCauseFailure = FunFixture[Result](
+    setup =
+      _ => Result.error(new Exception("example", new Exception("Expected"))),
+    teardown = _ => ()
+  )
+
+  val instanceMessageCauseAndFailure = FunFixture.map2(
+    FunFixture.map3(instance, exampleStr, failureThrowable),
+    resultFailCauseFailure
+  )
+
+  val resultFail = FunFixture[Result](
+    setup = _ => Result.error(new Exception("example")),
+    teardown = _ => ()
+  )
+
+  val instanceMessageAndFailure =
+    FunFixture.map3(instance, exampleStr, resultFail)
+
+  instance.test(
+    "withMunitAssertions passed assertions.assert should be munit.Assertions.assert"
+  ) { hedgehogAssertions =>
+    hedgehogAssertions.withMunitAssertions { assertions =>
+      assertNoDiff(
+        compileErrors("val x: Result = assertions.assert(true)"),
+        """|error:
+       |type mismatch;
+       | found   : Unit
+       | required: hedgehog.Result
+       |    (which expands to)  hedgehog.core.Result
+       |val x: Result = assertions.assert(true)
+       |                                 ^
+       |""".stripMargin
+      )
+    }
+  }
+
+  instance.test(
+    "withMunitAssertions passed assertions.assertEquals should be munit.Assert.assertEquals"
+  ) { hedgehogAssertions =>
+    hedgehogAssertions.withMunitAssertions { assertions =>
+      assertNoDiff(
+        compileErrors("val x: Result = assertions.assertEquals(true, true)"),
+        """|error:
+       |type mismatch;
+       | found   : Unit
+       | required: hedgehog.Result
+       |    (which expands to)  hedgehog.core.Result
+       |val x: Result = assertions.assertEquals(true, true)
+       |                                       ^
+       |""".stripMargin
+      )
+    }
+  }
+
+  instance.test(
+    "withMunitAssertions passed assertions.assertNoDiff should be munit.Assert.assertNoDiff"
+  )(hedgehogAssertions =>
+    hedgehogAssertions.withMunitAssertions { assertions =>
+      assertNoDiff(
+        compileErrors(
+          "val x: Result = assertions.assertNoDiff(\"true\", \"true\")"
+        ),
+        """|error:
+       |type mismatch;
+       | found   : Unit
+       | required: hedgehog.Result
+       |    (which expands to)  hedgehog.core.Result
+       |val x: Result = assertions.assertNoDiff("true", "true")
+       |                                       ^
+       |""".stripMargin
+      )
+    }
+  )
+
+  instance.test(
+    "withMunitAssertions passed assertions.assertNotEquals should be munit.Assert.assertNotEquals"
+  )(hedgehogAssertions =>
+    hedgehogAssertions.withMunitAssertions { assertions =>
+      assertNoDiff(
+        compileErrors(
+          "val x: Result = assertions.assertNotEquals(true, false)"
+        ),
+        """|error:
+       |type mismatch;
+       | found   : Unit
+       | required: hedgehog.Result
+       |    (which expands to)  hedgehog.core.Result
+       |val x: Result = assertions.assertNotEquals(true, false)
+       |                                          ^
+       |""".stripMargin
+      )
+    }
+  )
+
+  instance.test(
+    "withMunitAssertions passed assertions.assertEqualsDouble should be munit.Assert.assertEqualsDouble"
+  )(hedgehogAssertions =>
+    hedgehogAssertions.withMunitAssertions(assertions =>
+      assertNoDiff(
+        compileErrors(
+          "val x: Result = assertions.assertEqualsDouble(0.00, 0.00, 0.00)"
+        ),
+        """|error:
+       |type mismatch;
+       | found   : Unit
+       | required: hedgehog.Result
+       |    (which expands to)  hedgehog.core.Result
+       |val x: Result = assertions.assertEqualsDouble(0.00, 0.00, 0.00)
+       |                                             ^
+       |""".stripMargin
+      )
+    )
+  )
+
+  instance.test(
+    "withMunitAssertions passed assertions.assertEqualsFloat should be munit.Assert.assertEqualsFloat"
+  )(hedgehogAssertions =>
+    hedgehogAssertions.withMunitAssertions(assertions =>
+      assertNoDiff(
+        compileErrors(
+          "val x: Result = assertions.assertEqualsFloat(0.0f, 0.0f, 0.0f)"
+        ),
+        """|error:
+       |type mismatch;
+       | found   : Unit
+       | required: hedgehog.Result
+       |    (which expands to)  hedgehog.core.Result
+       |val x: Result = assertions.assertEqualsFloat(0.0f, 0.0f, 0.0f)
+       |                                            ^
+       |""".stripMargin
+      )
+    )
+  )
+
+  instance.test(
+    "withMunitAssertions passed assertions.fail should be munit.Assert.fail"
+  )(hedgehogAssertions =>
+    hedgehogAssertions.withMunitAssertions(assertions =>
+      assertNoDiff(
+        compileErrors(
+          "val x: Result = try{assertions.fail(\"this test should fail\")} catch { case e: Throwable => () }"
+        ),
+        """|error:
+       |type mismatch;
+       | found   : Unit
+       | required: hedgehog.Result
+       |    (which expands to)  hedgehog.core.Result
+       |val x: Result = try{assertions.fail("this test should fail")} catch { case e: Throwable => () }
+       |                                                                                           ^
+       |""".stripMargin
+      )
+    )
+  )
+
+  instance.test(
+    "withMunitAssertions passed assertions.fail(message, throwable) should be munit.Assert.fail(message, throwable)"
+  )(hedgehogAssertions =>
+    hedgehogAssertions.withMunitAssertions(assertions =>
+      assertNoDiff(
+        compileErrors(
+          "val x: Result = try{assertions.fail(\"this test should fail\", new Exception(\"fail!\"))} catch { case e: Throwable => () }"
+        ),
+        """|error:
+       |type mismatch;
+       | found   : Unit
+       | required: hedgehog.Result
+       |    (which expands to)  hedgehog.core.Result
+       |val x: Result = try{assertions.fail("this test should fail", new Exception("fail!"))} catch { case e: Throwable => () }
+       |                                                                                                                   ^
+       |""".stripMargin
+      )
+    )
+  )
+
+  instance.test(
+    "type Failure should be Result.Falure"
+  )(hedgehogAssertions =>
+    assertNoDiff(
+      compileErrors(
+        "val x: hedgehogAssertions.Failure = Result.Success"
+      ),
+      """|error:
+       |type mismatch;
+       | found   : hedgehog.Result.Success.type
+       | required: hedgehogAssertions.Failure
+       |    (which expands to)  hedgehog.Result.Failure
+       |val x: hedgehogAssertions.Failure = Result.Success
+       |                                           ^
+       |""".stripMargin
+    )
+  )
+
+  instance.test(
+    "type Success should be Result.Success"
+  )(hedgehogAssertions =>
+    assertNoDiff(
+      compileErrors(
+        "val x: hedgehogAssertions.Success = Result.Failure(List.empty[Log])"
+      ),
+      """|error:
+       |type mismatch;
+       | found   : hedgehog.Result.Failure
+       | required: hedgehogAssertions.Success
+       |    (which expands to)  hedgehog.Result.Success.type
+       |val x: hedgehogAssertions.Success = Result.Failure(List.empty[Log])
+       |                                                  ^
+       |""".stripMargin
+    )
+  )
+
+  instance.test("Success should be Result.Success") { hedgehogAssertions =>
+    assertEquals(hedgehogAssertions.Success, Result.Success)
+  }
+
+  instanceAndLog.test("Failure(log) should output a Result.Failure") {
+    case (hedgehogAssertions, resultLog) =>
+      assertEquals(
+        hedgehogAssertions.Failure(List(resultLog)),
+        Result.Failure(List(resultLog))
+      )
+  }
+
+  instance.test("success should be Result.success") { hedgehogAssertions =>
+    assertEquals(hedgehogAssertions.success, Result.success)
+  }
+
+  instance.test("failure should be Result.failure") { hedgehogAssertions =>
+    assertEquals(hedgehogAssertions.failure, Result.failure)
+  }
+
+  instanceAndFailException.test(
+    "error(exception) should be Result.error(exception)"
+  ) { case (hedgehogAssertions, exception) =>
+    assertEquals(hedgehogAssertions.error(exception), Result.error(exception))
+  }
+
+  instanceAndSuccess.test("all(results) should be Result.all(results)") {
+    case (hedgehogAssertions, successResult) =>
+      val results = List(successResult, successResult)
+      assertEquals(hedgehogAssertions.all(results), Result.all(results))
+  }
+
+  instanceAndResults.test("any(results) should be Result.any(reults)") {
+    case (hedgehogAssertions, successResult, failureResult) =>
+      val results = List(successResult, failureResult)
+      assertEquals(hedgehogAssertions.any(results), Result.any(results))
+  }
+
+  instanceExamplesAndComparisonFunction.test(
+    "diff(a, b)(comparison) should be Result.diff(a, b)(comparison)"
+  ) { case ((hedgehogAssertions, a, b), comparison) =>
+    assertEquals(
+      hedgehogAssertions.diff(a, b)(comparison),
+      Result.diff(a, b)(comparison)
+    )
+  }
+
+  instanceLogNameExamplesAndComparisonFunction.test(
+    "diffNamed(logName, a, b)(comparison) should be Result.diffNamed(logName, a, b)(comparison)"
+  ) { case ((((hedgehogAssertions, a, b), comparison), logName)) =>
+    assertEquals(
+      hedgehogAssertions.diffNamed(logName, a, b)(comparison),
+      Result.diffNamed(logName, a, b)(comparison)
+    )
+  }
+
+  instanceConditionClueAndSuccess.test(
+    "assert(true, clue) should be Result.Success"
+  ) { case ((hedgehogAssertions, condition, clue), resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assert(condition, clue),
+      resultSuccess
+    )
+  }
+
+  instanceConditionAndSuccess.test(
+    "assert(true) should be Result.Success"
+  ) { case (hedgehogAssertions, condition, success) =>
+    assertEquals(hedgehogAssertions.assert(condition), success)
+  }
+
+  instanceConditionAndFailure.test(
+    "assert(false) should be Result.Failure"
+  ) { case (hedgehogAssertions, failCond, failResult) =>
+    assertEquals(hedgehogAssertions.assert(failCond), failResult)
+  }
+
+  instanceAndExample1AndClueAndSuccess.test(
+    "assertEquals(example, example, clue) should be Result.success"
+  ) { case ((hedgehogAssertions, example, clue), success) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example, example, clue),
+      success
+    )
+  }
+
+  instanceExamplesAndClueAndFailureExamples.test(
+    "assertEquals(example1, example2, clue) should be Result.failure with a difference log"
+  ) { case ((hedgehogAssertions, example1, example2), clue, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example1, example2, clue),
+      resultFailure
+    )
+  }
+
+  instanceExamplesAndSuccess.test(
+    "assertEquals(example, example, clue), should be Success"
+  ) { case (hedgehogAssertions, example, resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example, example),
+      resultSuccess
+    )
+
+  }
+
+  instanceExamplesAndFailure.test(
+    "assertEquals(example1, example2) should be a Result.Failure with a log"
+  ) { case ((hedgehogAssertions, example1, example2), resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example1, example2),
+      resultFailure
+    )
+  }
+
+  instanceDoubleExampleClueAndSuccess.test(
+    "assertEqualsDouble(example, example, 0.00, clue), should be Success"
+  ) { case ((hedgehogAssertions, example, clue), resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example, example, 0.00),
+      resultSuccess
+    )
+  }
+
+  instanceDoubleExamplesDeltaClueAndSuccess.test(
+    "assertEqualsDouble(example1, example2, delta, clue) should be Success"
+  ) {
+    case (
+          ((hedgehogAssertions, example1, example2), delta, clue),
+          resultSuccess
+        ) =>
+      assertEquals(
+        hedgehogAssertions.assertEqualsDouble(example1, example2, delta, clue),
+        resultSuccess
+      )
+  }
+
+  instanceDoubleExamplesDeltaClueAndFailure.test(
+    "assertEqualsDouble(example1, example3, delta, clue) should be a failure with a diff log"
+  ) {
+    case (
+          ((hedgehogAssertions, example1, example2), delta, clue),
+          resultFailure
+        ) =>
+      assertEquals(
+        hedgehogAssertions.assertEqualsDouble(example1, example2, delta, clue),
+        resultFailure
+      )
+  }
+
+  instanceDoubleExamplesDeltaAndSuccess.test(
+    "diffDouble(example1, example2, delta) should be Success"
+  ) { case ((hedgehogAssertions, example1, example2), delta, resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.diffDouble(example1, example2, delta),
+      resultSuccess
+    )
+  }
+
+  instanceDoubleExamplesDeltaAndFailure.test(
+    "diffDouble(example1, example3, delta) should be Result.Failure with a diff log"
+  ) { case ((hedgehogAssertions, example1, example3), delta, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.diffDouble(example1, example3, delta),
+      resultFailure
+    )
+  }
+
+  instanceFloatExamplesDeltaClueAndSuccess.test(
+    "assertEqualsFloat(example1, example2, delta, clue) should be Success"
+  ) {
+    case (
+          ((hedgehogAssertions, example1, example2), delta, clue),
+          resultSuccess
+        ) =>
+      assertEquals(
+        hedgehogAssertions.assertEqualsFloat(example1, example2, delta, clue),
+        resultSuccess
+      )
+  }
+
+  instanceFloatExamplesDeltaClueAndFailure.test(
+    "assertEqualsFloat(example1, example3, delta, clue) should be Result.Failure with a diff log"
+  ) {
+    case (
+          ((hedgehogAssertions, example1, example3), delta, clue),
+          resultFailure
+        ) =>
+      assertEquals(
+        hedgehogAssertions.assertEqualsFloat(example1, example3, delta, clue),
+        resultFailure
+      )
+  }
+
+  instanceFloatExamplesDeltaAndSuccess.test(
+    "diffFloat(example1, example2, delta) should be Success"
+  ) { case ((hedgehogAssertions, example1, example2), delta, resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.diffFloat(example1, example2, delta),
+      resultSuccess
+    )
+  }
+
+  instanceFloatExamplesDeltaAndFailure.test(
+    "diffFloat(example1, example3, delta) should be Result.Failure with a diff log"
+  ) { case ((hedgehogAssertions, example1, example3), delta, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.diffFloat(example1, example3, delta),
+      resultFailure
+    )
+  }
+
+  instanceExampleClueAndSuccess.test(
+    "assertNoDiff(str, str, clue) should be Result.success"
+  ) { case ((hedgehogAssertions, str, clue), resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assertNoDiff(str, str, clue),
+      resultSuccess
+    )
+  }
+
+  instanceExamplesClueAndFailure.test(
+    "assertNoDiff(str, str2, clue) should be Result.failure"
+  ) { case ((hedgehogAssertions, str, str2), clue, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.assertNoDiff(str, str2, clue),
+      resultFailure
+    )
+  }
+
+  instanceExampleAndSuccess.test("assertNoDiff(str, str) should be Success") {
+    case (hedgehogAssertions, str, resultSuccess) =>
+      assertEquals(hedgehogAssertions.assertNoDiff(str, str), resultSuccess)
+  }
+
+  instanceExampleStringsAndFailure.test(
+    "assertNoDiff(str, str2) should be Result.failure"
+  ) { case ((hedgehogAssertions, str, str2), resultFailure) =>
+    assertEquals(hedgehogAssertions.assertNoDiff(str, str2), resultFailure)
+  }
+
+  instanceNonequalExamplesClueAndSuccess.test(
+    "assertNotEquals(str, str2, clue) should be Success"
+  ) { case ((hedgehogAssertions, str, str2), clue, resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assertNotEquals(str, str2, clue),
+      resultSuccess
+    )
+  }
+
+  instanceExampleClueAndFailure.test(
+    "assertNotEquals(str, str, clue) should be Result.failure with a diff log"
+  ) { case ((hedgehogAssertions, str, clue), resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.assertNotEquals(str, str, clue),
+      resultFailure
+    )
+  }
+
+  instanceNonequalExamplesAndSuccess.test(
+    "assertEquals(str, str2) should be Success"
+  ) { case ((hedgehogAssertions, str, str2), resultSucces) =>
+    assertEquals(hedgehogAssertions.assertNotEquals(str, str2), resultSucces)
+  }
+
+  instanceExampleStringAndFailure.test(
+    "assertEquals(str, str) should be resultFailure with a diff log"
+  ) { case (hedgehogAssertions, str, resultFailure) =>
+    assertEquals(hedgehogAssertions.assertNotEquals(str, str), resultFailure)
+  }
+
+  instanceMessageCauseAndFailure.test(
+    "fail(message, cause) should be a Result.failure with a message and cause log"
+  ) { case ((hedgehogAssertions, message, cause), resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.fail(message, cause).toString(),
+      resultFailure.toString()
+    )
+  }
+
+  instanceMessageAndFailure.test(
+    "fail(message) should be a Result.failure with a message"
+  ) { case (hedgehogAssertions, message, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.fail(message).toString(),
+      resultFailure.toString()
+    )
+  }
+}

--- a/munit/jvm/src/test/scala-2/hedgehog/munit/HedgehogSuiteIntegrationTest.scala
+++ b/munit/jvm/src/test/scala-2/hedgehog/munit/HedgehogSuiteIntegrationTest.scala
@@ -1,0 +1,48 @@
+package hedgehog
+package munit
+
+class HedgehogSuiteIntegrationTest extends HedgehogSuite {
+
+  lazy val intGen = Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).forAll
+
+  property("`property` works just like `test`, when it passes, it passes.") {
+    for {
+      x <- intGen
+    } yield Result.diff(x, x + 0)(_ == _)
+  }
+
+  property("`Result.type` members are directly available for use") {
+    for {
+      x <- intGen
+    } yield diff(x, x + 0)(_ == _)
+  }
+
+  property("`property` tests accept munit Assertions-like `assert*` results") {
+    for {
+      x <- intGen
+    } yield assertEquals(clue(x), clue(x + 0))
+
+  }
+
+  // uncomment to see compilation errors related to deprecation encouraging
+  // non-clue diff and diff delegating assertions
+  // property("passing clues explicitly will cause a deprecation warning for any munit-like assertions in HedgehogAssertions"){
+  //   for{
+  //     x <- intGenfor
+  //   } yield assertEquals(x, 2, clues(clue(x), clue(2)))
+  // }
+
+  // uncomment to see what HedgehogAssertions munit-like assert* test reports
+  // look like
+  // property("doing what the above deprecation says to do will result in a nice clue-like diff with a minimal failing example, hedgehog-style"){
+  //   for{
+  //     x <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).forAll
+  //   } yield assertEquals(x, 2)
+  // }
+
+  test(
+    "regular unit returning munit assertions work just fine, you just have to turn off the hedgehog assertions."
+  ) {
+    withMunitAssertions(assertions => assertions.assertEquals(1, 1))
+  }
+}

--- a/munit/jvm/src/test/scala-3/hedgehog/munit/HedgehogAssertionsSuite.scala
+++ b/munit/jvm/src/test/scala-3/hedgehog/munit/HedgehogAssertionsSuite.scala
@@ -1,0 +1,568 @@
+package hedgehog
+package munit
+
+import hedgehog.core.Log
+import _root_.munit.Assertions
+import _root_.munit.FunSuite
+
+class HedgehogAssertionsSuite extends FunSuite {
+
+  val instance = FunFixture[HedgehogAssertions](
+    setup = { test =>
+      new HedgehogAssertions with Assertions {}
+    },
+    teardown = { suite => () }
+  )
+
+  val resultSuccess =
+    FunFixture[Result](setup = test => Result.success, teardown = suite => ())
+
+  val resultFailure =
+    FunFixture[Result](setup = test => Result.failure, teardown = suite => ())
+
+  val results = FunFixture.map2(resultSuccess, resultFailure)
+
+  val instanceAndResults =
+    FunFixture.map3(instance, resultSuccess, resultFailure)
+
+  val exampleOne = FunFixture[Int](setup = test => 1, teardown = suite => ())
+
+  val exampleTwo = FunFixture[Int](setup = test => 2, teardown = suite => ())
+
+  val comparisonFunction = FunFixture[(Int, Int) => Boolean](
+    setup = test => (x: Int, y: Int) => x < y,
+    teardown = suite => ()
+  )
+
+  val instanceExamplesAndComparisonFunction = FunFixture.map2(
+    FunFixture.map3(instance, exampleOne, exampleTwo),
+    comparisonFunction
+  )
+
+  val logName =
+    FunFixture[String](setup = test => "logName", teardown = suite => ())
+
+  val instanceLogNameExamplesAndComparisonFunction =
+    FunFixture.map2(instanceExamplesAndComparisonFunction, logName)
+
+  val cond = FunFixture[Boolean](setup = test => true, teardown = suite => ())
+
+  val failCond =
+    FunFixture[Boolean](setup = test => false, teardown = suite => ())
+
+  val clue = FunFixture[String](setup = test => "clue", teardown = suite => ())
+
+  val instanceConditionAndClue = FunFixture.map3(instance, cond, clue)
+
+  val instanceConditionClueAndSuccess =
+    FunFixture.map2(instanceConditionAndClue, resultSuccess)
+
+  val failException = FunFixture[Exception](
+    setup = test => new Exception("fail!"),
+    teardown = suite => ()
+  )
+
+  val instanceAndSuccess = FunFixture.map2(instance, resultSuccess)
+
+  val instanceAndFailException = FunFixture.map2(instance, failException)
+
+  val log = FunFixture[Log](
+    setup = test => Log.String2Log("woot"),
+    teardown = suite => ()
+  )
+
+  val instanceAndLog = FunFixture.map2(instance, log)
+
+  val instanceConditionAndSuccess =
+    FunFixture.map3(instance, cond, resultSuccess)
+
+  val instanceConditionAndFailure =
+    FunFixture.map3(instance, failCond, resultFailure)
+
+  val instanceAndExample1AndClueAndSuccess =
+    FunFixture.map2(FunFixture.map3(instance, exampleOne, clue), resultSuccess)
+
+  val failResult = FunFixture[Result](
+    setup = test =>
+      Result.failure
+        .log("=== Failed ===")
+        .log("--- lhs ---")
+        .log("1")
+        .log("--- rhs ---")
+        .log("2"),
+    teardown = suite => ()
+  )
+
+  val instanceExamplesAndClueAndFailureExamples =
+    FunFixture.map3(
+      FunFixture.map3(instance, exampleOne, exampleTwo),
+      clue,
+      failResult
+    )
+
+  val instanceExamplesAndSuccess =
+    FunFixture.map3(instance, exampleOne, resultSuccess)
+
+  val instanceExamplesAndFailure = FunFixture.map2(
+    FunFixture.map3(instance, exampleOne, exampleTwo),
+    failResult
+  )
+
+  val doubleExample =
+    FunFixture[Double](setup = testOptions => 1.00, teardown = _ => ())
+
+  val doubleExample2 =
+    FunFixture[Double](setup = testOptions => 2.00, teardown = _ => ())
+
+  val doubleExample3 =
+    FunFixture[Double](setup = testOptions => 3.00, teardown = _ => ())
+
+  val instanceDoubleExampleClueAndSuccess = FunFixture.map2(
+    FunFixture.map3(instance, doubleExample, clue),
+    resultSuccess
+  )
+
+  val deltaDouble =
+    FunFixture[Double](setup = testOptions => 1.00, teardown = _ => ())
+
+  val instanceDoubleExamplesDeltaClueAndSuccess = FunFixture.map2(
+    FunFixture.map3(
+      FunFixture.map3(instance, doubleExample, doubleExample2),
+      deltaDouble,
+      clue
+    ),
+    resultSuccess
+  )
+
+  val resultDeltaFailure = FunFixture[Result](
+    setup = testOptions => {
+      Result.failure
+        .log("=== Failed ===")
+        .log("--- lhs ---")
+        .log("1.0")
+        .log("--- rhs ---")
+        .log("3.0")
+    },
+    teardown = _ => ()
+  )
+
+  val instanceDoubleExamplesDeltaClueAndFailure = FunFixture.map2(
+    FunFixture.map3(
+      FunFixture.map3(instance, doubleExample, doubleExample3),
+      deltaDouble,
+      clue
+    ),
+    resultDeltaFailure
+  )
+
+  val instanceDoubleExamplesDeltaAndSuccess = FunFixture.map3(
+    FunFixture.map3(instance, doubleExample, doubleExample2),
+    deltaDouble,
+    resultSuccess
+  )
+
+  val instanceDoubleExamplesDeltaAndFailure = FunFixture.map3(
+    FunFixture.map3(instance, doubleExample, doubleExample3),
+    deltaDouble,
+    resultDeltaFailure
+  )
+
+  val floatExample = FunFixture[Float](setup = _ => 1.0f, teardown = _ => ())
+  val floatExample2 = FunFixture[Float](setup = _ => 2.0f, teardown = _ => ())
+  val floatDelta = FunFixture[Float](setup = _ => 1.0f, teardown = _ => ())
+  val instanceFloatExamplesDeltaClueAndSuccess = FunFixture.map2(
+    FunFixture.map3(
+      FunFixture.map3(instance, floatExample, floatExample2),
+      floatDelta,
+      clue
+    ),
+    resultSuccess
+  )
+
+  val floatExample3 = FunFixture[Float](setup = _ => 3.0f, teardown = _ => ())
+
+  val instanceFloatExamplesDeltaClueAndFailure = FunFixture.map2(
+    FunFixture.map3(
+      FunFixture.map3(instance, floatExample, floatExample3),
+      floatDelta,
+      clue
+    ),
+    resultDeltaFailure
+  )
+
+  val instanceFloatExamplesDeltaAndSuccess = FunFixture.map3(
+    FunFixture.map3(instance, floatExample, floatExample2),
+    floatDelta,
+    resultSuccess
+  )
+
+  val instanceFloatExamplesDeltaAndFailure = FunFixture.map3(
+    FunFixture.map3(instance, floatExample, floatExample3),
+    floatDelta,
+    resultDeltaFailure
+  )
+
+  val exampleStr =
+    FunFixture[String](setup = _ => "example", teardown = _ => ())
+
+  val instanceExampleClueAndSuccess =
+    FunFixture.map2(FunFixture.map3(instance, exampleStr, clue), resultSuccess)
+
+  val exampleStr2 =
+    FunFixture[String](setup = _ => "example2", teardown = _ => ())
+
+  val instanceExamplesClueAndFailure = FunFixture.map3(
+    FunFixture.map3(instance, exampleStr, exampleStr2),
+    clue,
+    resultFailure
+  )
+
+  val instanceExampleAndSuccess =
+    FunFixture.map3(instance, exampleStr, resultSuccess)
+
+  val instanceExampleStringsAndFailure = FunFixture.map2(
+    FunFixture.map3(instance, exampleStr, exampleStr2),
+    resultFailure
+  )
+
+  val instanceNonequalExamplesClueAndSuccess = FunFixture.map3(
+    FunFixture.map3(instance, exampleStr, exampleStr2),
+    clue,
+    resultSuccess
+  )
+
+  val resultStringFailure = FunFixture[Result](
+    setup = _ =>
+      Result.failure
+        .log("=== Failed ===")
+        .log("--- lhs ---")
+        .log("example")
+        .log("--- rhs ---")
+        .log("example"),
+    teardown = _ => ()
+  )
+
+  val instanceExampleClueAndFailure = FunFixture.map2(
+    FunFixture.map3(instance, exampleStr, clue),
+    resultStringFailure
+  )
+
+  val instanceNonequalExamplesAndSuccess = FunFixture.map2(
+    FunFixture.map3(instance, exampleStr, exampleStr2),
+    resultSuccess
+  )
+
+  val resultStringEqualFailure = FunFixture[Result](
+    setup = _ =>
+      Result.failure
+        .log("=== Failed ===")
+        .log("--- lhs ---")
+        .log("example")
+        .log("--- rhs ---")
+        .log("example"),
+    teardown = _ => ()
+  )
+
+  val instanceExampleStringAndFailure =
+    FunFixture.map3(instance, exampleStr, resultStringEqualFailure)
+
+  val failureThrowable = FunFixture[Throwable](
+    setup = _ => new Exception("Expected"),
+    teardown = _ => ()
+  )
+
+  val resultFailCauseFailure = FunFixture[Result](
+    setup =
+      _ => Result.error(new Exception("example", new Exception("Expected"))),
+    teardown = _ => ()
+  )
+
+  val instanceMessageCauseAndFailure = FunFixture.map2(
+    FunFixture.map3(instance, exampleStr, failureThrowable),
+    resultFailCauseFailure
+  )
+
+  val resultFail = FunFixture[Result](
+    setup = _ => Result.error(new Exception("example")),
+    teardown = _ => ()
+  )
+
+  val instanceMessageAndFailure =
+    FunFixture.map3(instance, exampleStr, resultFail)
+
+  instance.test("success should be Result.success") { hedgehogAssertions =>
+    assertEquals(hedgehogAssertions.success, Result.success)
+  }
+
+  instance.test("failure should be Result.failure") { hedgehogAssertions =>
+    assertEquals(hedgehogAssertions.failure, Result.failure)
+  }
+
+  instanceAndFailException.test(
+    "error(exception) should be Result.error(exception)"
+  ) { case (hedgehogAssertions, exception) =>
+    assertEquals(hedgehogAssertions.error(exception), Result.error(exception))
+  }
+
+  instanceAndSuccess.test("all(results) should be Result.all(results)") {
+    case (hedgehogAssertions, successResult) =>
+      val results = List(successResult, successResult)
+      assertEquals(hedgehogAssertions.all(results), Result.all(results))
+  }
+
+  instanceAndResults.test("any(results) should be Result.any(reults)") {
+    case (hedgehogAssertions, successResult, failureResult) =>
+      val results = List(successResult, failureResult)
+      assertEquals(hedgehogAssertions.any(results), Result.any(results))
+  }
+
+  instanceExamplesAndComparisonFunction.test(
+    "diff(a, b)(comparison) should be Result.diff(a, b)(comparison)"
+  ) { case ((hedgehogAssertions, a, b), comparison) =>
+    assertEquals(
+      hedgehogAssertions.diff(a, b)(comparison),
+      Result.diff(a, b)(comparison)
+    )
+  }
+
+  instanceLogNameExamplesAndComparisonFunction.test(
+    "diffNamed(logName, a, b)(comparison) should be Result.diffNamed(logName, a, b)(comparison)"
+  ) { case ((((hedgehogAssertions, a, b), comparison), logName)) =>
+    assertEquals(
+      hedgehogAssertions.diffNamed(logName, a, b)(comparison),
+      Result.diffNamed(logName, a, b)(comparison)
+    )
+  }
+
+  instanceConditionClueAndSuccess.test(
+    "assert(true, clue) should be Result.Success"
+  ) { case ((hedgehogAssertions, condition, clue), resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assert(condition, clue),
+      resultSuccess
+    )
+  }
+
+  instanceConditionAndSuccess.test(
+    "assert(true) should be Result.Success"
+  ) { case (hedgehogAssertions, condition, success) =>
+    assertEquals(hedgehogAssertions.assert(condition), success)
+  }
+
+  instanceConditionAndFailure.test(
+    "assert(false) should be Result.Failure"
+  ) { case (hedgehogAssertions, failCond, failResult) =>
+    assertEquals(hedgehogAssertions.assert(failCond), failResult)
+  }
+
+  instanceAndExample1AndClueAndSuccess.test(
+    "assertEquals(example, example, clue) should be Result.success"
+  ) { case ((hedgehogAssertions, example, clue), success) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example, example, clue),
+      success
+    )
+  }
+
+  instanceExamplesAndClueAndFailureExamples.test(
+    "assertEquals(example1, example2, clue) should be Result.failure with a difference log"
+  ) { case ((hedgehogAssertions, example1, example2), clue, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example1, example2, clue),
+      resultFailure
+    )
+  }
+
+  instanceExamplesAndSuccess.test(
+    "assertEquals(example, example, clue), should be Success"
+  ) { case (hedgehogAssertions, example, resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example, example),
+      resultSuccess
+    )
+
+  }
+
+  instanceExamplesAndFailure.test(
+    "assertEquals(example1, example2) should be a Result.Failure with a log"
+  ) { case ((hedgehogAssertions, example1, example2), resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example1, example2),
+      resultFailure
+    )
+  }
+
+  instanceDoubleExampleClueAndSuccess.test(
+    "assertEqualsDouble(example, example, 0.00, clue), should be Success"
+  ) { case ((hedgehogAssertions, example, clue), resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assertEquals(example, example, 0.00),
+      resultSuccess
+    )
+  }
+
+  instanceDoubleExamplesDeltaClueAndSuccess.test(
+    "assertEqualsDouble(example1, example2, delta, clue) should be Success"
+  ) {
+    case (
+          ((hedgehogAssertions, example1, example2), delta, clue),
+          resultSuccess
+        ) =>
+      assertEquals(
+        hedgehogAssertions.assertEqualsDouble(example1, example2, delta, clue),
+        resultSuccess
+      )
+  }
+
+  instanceDoubleExamplesDeltaClueAndFailure.test(
+    "assertEqualsDouble(example1, example3, delta, clue) should be a failure with a diff log"
+  ) {
+    case (
+          ((hedgehogAssertions, example1, example2), delta, clue),
+          resultFailure
+        ) =>
+      assertEquals(
+        hedgehogAssertions.assertEqualsDouble(example1, example2, delta, clue),
+        resultFailure
+      )
+  }
+
+  instanceDoubleExamplesDeltaAndSuccess.test(
+    "diffDouble(example1, example2, delta) should be Success"
+  ) { case ((hedgehogAssertions, example1, example2), delta, resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.diffDouble(example1, example2, delta),
+      resultSuccess
+    )
+  }
+
+  instanceDoubleExamplesDeltaAndFailure.test(
+    "diffDouble(example1, example3, delta) should be Result.Failure with a diff log"
+  ) { case ((hedgehogAssertions, example1, example3), delta, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.diffDouble(example1, example3, delta),
+      resultFailure
+    )
+  }
+
+  instanceFloatExamplesDeltaClueAndSuccess.test(
+    "assertEqualsFloat(example1, example2, delta, clue) should be Success"
+  ) {
+    case (
+          ((hedgehogAssertions, example1, example2), delta, clue),
+          resultSuccess
+        ) =>
+      assertEquals(
+        hedgehogAssertions.assertEqualsFloat(example1, example2, delta, clue),
+        resultSuccess
+      )
+  }
+
+  instanceFloatExamplesDeltaClueAndFailure.test(
+    "assertEqualsFloat(example1, example3, delta, clue) should be Result.Failure with a diff log"
+  ) {
+    case (
+          ((hedgehogAssertions, example1, example3), delta, clue),
+          resultFailure
+        ) =>
+      assertEquals(
+        hedgehogAssertions.assertEqualsFloat(example1, example3, delta, clue),
+        resultFailure
+      )
+  }
+
+  instanceFloatExamplesDeltaAndSuccess.test(
+    "diffFloat(example1, example2, delta) should be Success"
+  ) { case ((hedgehogAssertions, example1, example2), delta, resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.diffFloat(example1, example2, delta),
+      resultSuccess
+    )
+  }
+
+  instanceFloatExamplesDeltaAndFailure.test(
+    "diffFloat(example1, example3, delta) should be Result.Failure with a diff log"
+  ) { case ((hedgehogAssertions, example1, example3), delta, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.diffFloat(example1, example3, delta),
+      resultFailure
+    )
+  }
+
+  instanceExampleClueAndSuccess.test(
+    "assertNoDiff(str, str, clue) should be Result.success"
+  ) { case ((hedgehogAssertions, str, clue), resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assertNoDiff(str, str, clue),
+      resultSuccess
+    )
+  }
+
+  instanceExamplesClueAndFailure.test(
+    "assertNoDiff(str, str2, clue) should be Result.failure"
+  ) { case ((hedgehogAssertions, str, str2), clue, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.assertNoDiff(str, str2, clue),
+      resultFailure
+    )
+  }
+
+  instanceExampleAndSuccess.test("assertNoDiff(str, str) should be Success") {
+    case (hedgehogAssertions, str, resultSuccess) =>
+      assertEquals(hedgehogAssertions.assertNoDiff(str, str), resultSuccess)
+  }
+
+  instanceExampleStringsAndFailure.test(
+    "assertNoDiff(str, str2) should be Result.failure"
+  ) { case ((hedgehogAssertions, str, str2), resultFailure) =>
+    assertEquals(hedgehogAssertions.assertNoDiff(str, str2), resultFailure)
+  }
+
+  instanceNonequalExamplesClueAndSuccess.test(
+    "assertNotEquals(str, str2, clue) should be Success"
+  ) { case ((hedgehogAssertions, str, str2), clue, resultSuccess) =>
+    assertEquals(
+      hedgehogAssertions.assertNotEquals(str, str2, clue),
+      resultSuccess
+    )
+  }
+
+  instanceExampleClueAndFailure.test(
+    "assertNotEquals(str, str, clue) should be Result.failure with a diff log"
+  ) { case ((hedgehogAssertions, str, clue), resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.assertNotEquals(str, str, clue),
+      resultFailure
+    )
+  }
+
+  instanceNonequalExamplesAndSuccess.test(
+    "assertEquals(str, str2) should be Success"
+  ) { case ((hedgehogAssertions, str, str2), resultSucces) =>
+    assertEquals(hedgehogAssertions.assertNotEquals(str, str2), resultSucces)
+  }
+
+  instanceExampleStringAndFailure.test(
+    "assertEquals(str, str) should be resultFailure with a diff log"
+  ) { case (hedgehogAssertions, str, resultFailure) =>
+    assertEquals(hedgehogAssertions.assertNotEquals(str, str), resultFailure)
+  }
+
+  instanceMessageCauseAndFailure.test(
+    "fail(message, cause) should be a Result.failure with a message and cause log"
+  ) { case ((hedgehogAssertions, message, cause), resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.fail(message, cause).toString(),
+      resultFailure.toString()
+    )
+  }
+
+  instanceMessageAndFailure.test(
+    "fail(message) should be a Result.failure with a message"
+  ) { case (hedgehogAssertions, message, resultFailure) =>
+    assertEquals(
+      hedgehogAssertions.fail(message).toString(),
+      resultFailure.toString()
+    )
+  }
+}

--- a/munit/jvm/src/test/scala-3/hedgehog/munit/HedgehogSuiteIntegrationTest.scala
+++ b/munit/jvm/src/test/scala-3/hedgehog/munit/HedgehogSuiteIntegrationTest.scala
@@ -1,0 +1,48 @@
+package hedgehog
+package munit
+
+class HedgehogSuiteIntegrationTest extends HedgehogSuite {
+
+  lazy val intGen = Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).forAll
+
+  property("`property` works just like `test`, when it passes, it passes.") {
+    for {
+      x <- intGen
+    } yield Result.diff(x, x + 0)(_ == _)
+  }
+
+  property("`Result.type` members are directly available for use") {
+    for {
+      x <- intGen
+    } yield diff(x, x + 0)(_ == _)
+  }
+
+  property("`property` tests accept munit Assertions-like `assert*` results") {
+    for {
+      x <- intGen
+    } yield assertEquals(clue(x), clue(x + 0))
+
+  }
+
+  // uncomment to see compilation errors related to deprecation encouraging
+  // non-clue diff and diff delegating assertions
+  // property("passing clues explicitly will cause a deprecation warning for any munit-like assertions in HedgehogAssertions"){
+  //   for{
+  //     x <- intGenfor
+  //   } yield assertEquals(x, 2, clues(clue(x), clue(2)))
+  // }
+
+  // uncomment to see what HedgehogAssertions munit-like assert* test reports
+  // look like
+  // property("doing what the above deprecation says to do will result in a nice clue-like diff with a minimal failing example, hedgehog-style"){
+  //   for{
+  //     x <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).forAll
+  //   } yield assertEquals(x, 2)
+  // }
+
+  test(
+    "regular unit returning munit assertions work just fine, you just have to turn off the hedgehog assertions."
+  ) {
+    withMunitAssertions(assertions => assertions.assertEquals(1, 1))
+  }
+}

--- a/munit/shared/src/main/scala-2.11/hedgehog/munit/HedgehogAssertions.scala
+++ b/munit/shared/src/main/scala-2.11/hedgehog/munit/HedgehogAssertions.scala
@@ -1,0 +1,382 @@
+package hedgehog
+package munit
+
+import hedgehog.{core => hc}
+import _root_.munit.Assertions
+
+import java.{lang => jl}
+
+/** Mirrors munit.Assertions assertions, allowing munit users to use familiar
+  * assertions while returning proper hedgehog.Result objects in property tests.
+  *
+  * Signatures don't line up exactly -- munit.Assertions is not F-bound
+  * polymorphic, so there is no way to align the signatures of the same
+  * argumentns with different return types in scala. We can, however, simply
+  * omit the implicit location arguments, because hedgehog.Result doesn't
+  * require munit.Location. Except in cases where Location is passed explicitly
+  * (which should be rare in user code), this should result in fairly easy
+  * adoption by munit and munit-scalacheck users.
+  */
+trait HedgehogAssertions { self: Assertions =>
+
+  /** Turns off hedgehog munit-like assertions, so users can use both property-
+    * and non-property- based-tests in their test suites. By using the passed
+    * assertions parameter, all the standard munit assertions that do not return
+    * unit are available, despite name ambiguities.
+    *
+    * ==Usage==
+    * {{{
+    *   test("1 + 1 is 2"){
+    *     withMunitAssertions{ assertions =>
+    *       assertEquals(1 + 1, 2)
+    *     }
+    *   }
+    * }}}
+    *
+    * @param body
+    *   a test body, taking an assertions parameter
+    * @return
+    */
+  def withMunitAssertions(body: => Assertions => Any): Any = body(
+    this.asInstanceOf[Assertions]
+  )
+
+  /** @see
+    *   hedgehog.core.Result.Failure
+    */
+  type Failure = Result.Failure
+
+  /** @see
+    *   hedgehog.core.Result.Success
+    */
+  type Success = Result.Success.type
+
+  /** Alias for Result.Success
+    *
+    * @see
+    *   hedgehog.core.Result.Success
+    */
+  lazy val Success: Success = Result.Success
+
+  /** Alias for Result.Failure
+    *
+    * @see
+    *   See hedgehog.core.Result.Failure
+    */
+  def Failure(log: List[hc.Log]) = Result.Failure(log)
+
+  /** Alias for Result.success
+    *
+    * @see
+    *   hedgehog.core.Result.success
+    */
+  def success = Result.success
+
+  /** Alias for Result.failure
+    *
+    * @see
+    *   hedgehog.core.Result.failure
+    */
+  def failure = Result.failure
+
+  /** Alias for Result.error
+    *
+    * @see
+    *   hedgehog.core.Result.error
+    */
+  def error(e: Exception) = Result.error(e)
+
+  /** Alias for Result.all
+    *
+    * @see
+    *   hedgehog.core.Result.all
+    */
+  def all(l: List[Result]) = Result.all(l)
+
+  /** Alias for Result.any
+    *
+    * @see
+    *   hedgehog.core.Result.any
+    */
+  def any(l: List[Result]) = Result.any(l)
+
+  /** Alias for Result.diff
+    *
+    * @see
+    *   hedgehog.core.Result.diff
+    */
+  def diff[A, B](a: A, b: B)(f: (A, B) => Boolean) = Result.diff(a, b)(f)
+
+  /** Alias for Result.diffNamed
+    *
+    * @see
+    *   hedgehog.core.Result.diffNamed
+    */
+  def diffNamed[A, B](logName: String, a: A, b: B)(f: (A, B) => Boolean) =
+    Result.diffNamed(logName, a, b)(f)
+
+  /** Fails the test with a failure Result when `cond` is `false`.
+    *
+    * Analagous to munit.Assertions.assert.
+    *
+    * Only the condition is used. Clues are ignored.
+    *
+    * @param cond
+    * @param clue
+    *   ignored -- usage triggers the deprecation warning
+    * @return
+    *   Success iff cond is true. Failure otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.diff, which will automatically output clues",
+    ""
+  )
+  def assert(cond: => Boolean, clue: => Any): Result =
+    Result.assert(
+      cond
+    )
+
+  /** Fails the test with a failure Result when `cond` is `false`.
+    *
+    * @param cond
+    * @return
+    *   Success iff cond is true. Failure otherwise.
+    */
+  def assert(cond: => Boolean): Result = Result.assert(cond)
+
+  /** Fails the test if `obtained` and `expected` are non-equal using `==`.
+    *
+    * Analagous to munit.Assertions.assert.
+    *
+    * Only the obtained and expected values are used.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    * @param clue
+    *   Ignored -- Triggers deprecation warning
+    * @param ev
+    *   Evidence that A and B are of the same type for the comparison to be
+    *   valid.
+    * @return
+    *   Success iff obtained == expected. Failure otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.assertEquals, which will automatically output clues",
+    ""
+  )
+  def assertEquals[A, B](obtained: A, expected: B, clue: => Any)(implicit
+      ev: B <:< A
+  ): Result = assertEquals(obtained, expected)
+
+  /** Fails the test if `obtained` and `expected` are non-equal using `==`.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    *   The expected value
+    * @return
+    *   Success iff obtained == expected. Failure otherwise.
+    */
+  def assertEquals[A, B](obtained: A, expected: B)(implicit
+      ev: B <:< A
+  ): Result =
+    diff(obtained, expected)(_ == _)
+
+  /** Double specialized version of `HedgehogAssertions.assertEquals`.
+    *
+    * Asserts two double values are equal +- some error value.
+    *
+    * Analagous to munit.Assertions.assertEqualsDouble.
+    *
+    * Only the obtained, expected and delta parameters are used.
+    *
+    * @param obtained
+    *   The actual value.
+    * @param expected
+    *   The expected value.
+    * @param delta
+    *   The error allowed for double == comparison.
+    * @param clue
+    *   Ignored -- usage triggers a deprecation warning
+    * @return
+    *   Success iff obtained approximately equals expected +- delta. Failure
+    *   otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.diffDouble, which will automatically output clues",
+    ""
+  )
+  def assertEqualsDouble(
+      obtained: Double,
+      expected: Double,
+      delta: Double,
+      clue: => Any
+  ): Result = diffDouble(obtained, expected, delta)
+
+  /** Asserts two doubles are equal +- some erorr value.
+    *
+    * @param obtained
+    *   The actual value.
+    * @param expected
+    *   The expected value.
+    * @param delta
+    *   The error allowed for double == comparison. Default is 0.00.
+    * @return
+    *   Success iff obtained approximately equals expected +- delta. Failure
+    *   otherwis
+    */
+  def diffDouble(
+      obtained: Double,
+      expected: Double,
+      delta: Double = 0.00
+  ): Result =
+    diff(obtained, expected) { (a, b) =>
+      jl.Double.compare(expected, obtained) == 0 || Math.abs(
+        expected - obtained
+      ) <= delta
+    }
+
+  /** Float specialized version of assertEquals.
+    *
+    * Asserts two floats are equal within +- some error value.
+    *
+    * Analagous to munit.Assertions.assertEqualsFloat.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    *   The expected value
+    * @param delta
+    *   The error allowed for float == comparison.
+    * @param clue
+    *   Ignored -- usage triggers deprecation warning
+    * @return
+    *   Success iff obtained approximately equals expected +- delta. Failure
+    *   otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.diffFloat, which will automatically output clues",
+    ""
+  )
+  def assertEqualsFloat(
+      obtained: Float,
+      expected: Float,
+      delta: Float,
+      clue: => Any
+  ): Result = diffFloat(obtained, expected, delta)
+
+  /** Float specialized version of HedgehogAssertions.assertEquals.
+    *
+    * Asserts two floats are equal within +- some error value.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    *   The expected value
+    * @param delta
+    *   The error allowed for float == comparison. Default is 0.0f
+    * @return
+    *   Success iff obtained approximately equals expected +- delta. Failure
+    *   otherwise.
+    */
+  def diffFloat(obtained: Float, expected: Float, delta: Float = 0.0f): Result =
+    Result.diff(obtained, expected) { (a, b) =>
+      jl.Float.compare(a, b) == 0 || Math.abs(expected - obtained) <= delta
+    }
+
+  /** Asserts two strings are equal without outputting a diff.
+    *
+    * Analagous to munit.Assertions.assertNoDiff.
+    *
+    * @param obtained
+    *   The actual string
+    * @param expected
+    *   The expected string
+    * @param clue
+    *   Ignored -- usage triggers a deprecation warning
+    * @return
+    *   Success iff actual is obtained. Failure otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.diff, which will automatically output clues",
+    ""
+  )
+  def assertNoDiff(obtained: String, expected: String, clue: => Any): Result =
+    assertNoDiff(obtained, expected)
+
+  /** Asserts two strings are equal.
+    *
+    * @param obtained
+    *   The actual string
+    * @param expected
+    *   The expected value
+    * @return
+    *   Success iff actual is obtained. Failure otherwise.
+    */
+  def assertNoDiff(obtained: String, expected: String): Result = assert(
+    obtained == expected
+  )
+
+  /** Asserts obtained is not equal to expected using ==.
+    *
+    * Analagous to munit.Assertions.notEquals.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    *   The expected value
+    * @param clue
+    *   Ignored -- Usage triggers a deprecation warning
+    * @param ev
+    *   Evidence that obtained and expected are of the same type.
+    * @return
+    *   Success iff obtained != expected. Failure otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.assertNotEquals, which will automatically output clues",
+    ""
+  )
+  def assertNotEquals[A, B](obtained: A, expected: B, clue: => Any)(implicit
+      ev: A =:= B
+  ): Result = assertNotEquals(obtained, expected)
+
+  /** Asserts two values are nonequal.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    *   The expected value
+    * @param ev
+    *   Ensures that obtained and expected are of the same type.
+    * @return
+    *   Success iff obtained != actua.
+    */
+  def assertNotEquals[A, B](obtained: A, expected: B)(implicit
+      ev: A =:= B
+  ): Result = diff(obtained, expected)(_ != _)
+
+  /** Fails a test.
+    *
+    * Analagous to munit.Assertions.fail.
+    *
+    * @param message
+    *   The message to include in the failure.
+    * @param cause
+    *   An optional underlying exception to use as the cause of the failure.
+    * @return
+    *   Failure, always.
+    */
+  def fail(message: String, cause: Throwable): Result =
+    failure.log(hc.Error(new Exception(message, cause)))
+
+  /** Fails a test with the given message
+    *
+    * @param message
+    * @return
+    *   Failure, always.
+    */
+  def fail(message: String): Result =
+    failure.log(hc.Error(new Exception(message)))
+
+}

--- a/munit/shared/src/main/scala-2.11/hedgehog/munit/HedgehogSuite.scala
+++ b/munit/shared/src/main/scala-2.11/hedgehog/munit/HedgehogSuite.scala
@@ -1,0 +1,55 @@
+package hedgehog
+package munit
+
+import hedgehog.core.PropertyConfig
+import hedgehog.core.Seed
+import hedgehog.core.Status
+import hedgehog.{runner => hr}
+import _root_.munit.FunSuite
+import _root_.munit.Location
+
+abstract class HedgehogSuite extends FunSuite with HedgehogAssertions {
+
+  private val seedSource = hr.SeedSource.fromEnvOrTime()
+
+  private val seed: Seed = Seed.fromLong(seedSource.seed)
+
+  /** Runs a hedgehog property-based test.
+    *
+    * @see
+    *   hedgehog.runner.property
+    * @param name
+    * @param withConfig
+    *   A function with which to change the test PropertyConfig
+    * @param prop
+    *   The property under test
+    * @param loc
+    *   The location in the test suite source file
+    */
+  def property(
+      name: String,
+      withConfig: PropertyConfig => PropertyConfig = identity
+  )(
+      prop: => Property
+  )(implicit loc: Location): Unit = {
+    val t = hedgehog.runner.property(name, prop).config(withConfig)
+    test(name)(check(t, t.withConfig(PropertyConfig.default)))
+  }
+
+  private def check(test: hr.Test, config: PropertyConfig)(implicit
+      loc: Location
+  ): Any = {
+    val report = Property.check(test.withConfig(config), test.result, seed)
+    if (report.status != Status.ok) {
+      val reason = hr.Test.renderReport(
+        this.getClass.getName,
+        test,
+        report,
+        ansiCodesSupported = true
+      )
+      withMunitAssertions(assertions =>
+        assertions.fail(s"$reason\n${seedSource.renderLog}")
+      )
+    }
+  }
+}

--- a/munit/shared/src/main/scala-2.12/hedgehog/munit/HedgehogAssertions.scala
+++ b/munit/shared/src/main/scala-2.12/hedgehog/munit/HedgehogAssertions.scala
@@ -1,0 +1,386 @@
+package hedgehog
+package munit
+
+import hedgehog.{core => hc}
+import _root_.munit.Assertions
+
+import scala.annotation.nowarn
+
+import java.{lang => jl}
+
+/** Mirrors munit.Assertions assertions, allowing munit users to use familiar
+  * assertions while returning proper hedgehog.Result objects in property tests.
+  *
+  * Signatures don't line up exactly -- munit.Assertions is not F-bound
+  * polymorphic, so there is no way to align the signatures of the same
+  * argumentns with different return types in scala. We can, however, simply
+  * omit the implicit location arguments, because hedgehog.Result doesn't
+  * require munit.Location. Except in cases where Location is passed explicitly
+  * (which should be rare in user code), this should result in fairly easy
+  * adoption by munit and munit-scalacheck users.
+  */
+trait HedgehogAssertions { self: Assertions =>
+
+  /** Turns off hedgehog munit-like assertions, so users can use both property-
+    * and non-property- based-tests in their test suites. By using the passed
+    * assertions parameter, all the standard munit assertions that do not return
+    * unit are available, despite name ambiguities.
+    *
+    * ==Usage==
+    * {{{
+    *   test("1 + 1 is 2"){
+    *     withMunitAssertions{ assertions =>
+    *       assertEquals(1 + 1, 2)
+    *     }
+    *   }
+    * }}}
+    *
+    * @param body
+    *   a test body, taking an assertions parameter
+    * @return
+    */
+  def withMunitAssertions(body: => Assertions => Any): Any = body(
+    this.asInstanceOf[Assertions]
+  )
+
+  /** @see
+    *   hedgehog.core.Result.Failure
+    */
+  type Failure = Result.Failure
+
+  /** @see
+    *   hedgehog.core.Result.Success
+    */
+  type Success = Result.Success.type
+
+  /** Alias for Result.Success
+    *
+    * @see
+    *   hedgehog.core.Result.Success
+    */
+  lazy val Success: Success = Result.Success
+
+  /** Alias for Result.Failure
+    *
+    * @see
+    *   See hedgehog.core.Result.Failure
+    */
+  def Failure(log: List[hc.Log]) = Result.Failure(log)
+
+  /** Alias for Result.success
+    *
+    * @see
+    *   hedgehog.core.Result.success
+    */
+  def success = Result.success
+
+  /** Alias for Result.failure
+    *
+    * @see
+    *   hedgehog.core.Result.failure
+    */
+  def failure = Result.failure
+
+  /** Alias for Result.error
+    *
+    * @see
+    *   hedgehog.core.Result.error
+    */
+  def error(e: Exception) = Result.error(e)
+
+  /** Alias for Result.all
+    *
+    * @see
+    *   hedgehog.core.Result.all
+    */
+  def all(l: List[Result]) = Result.all(l)
+
+  /** Alias for Result.any
+    *
+    * @see
+    *   hedgehog.core.Result.any
+    */
+  def any(l: List[Result]) = Result.any(l)
+
+  /** Alias for Result.diff
+    *
+    * @see
+    *   hedgehog.core.Result.diff
+    */
+  def diff[A, B](a: A, b: B)(f: (A, B) => Boolean) = Result.diff(a, b)(f)
+
+  /** Alias for Result.diffNamed
+    *
+    * @see
+    *   hedgehog.core.Result.diffNamed
+    */
+  def diffNamed[A, B](logName: String, a: A, b: B)(f: (A, B) => Boolean) =
+    Result.diffNamed(logName, a, b)(f)
+
+  /** Fails the test with a failure Result when `cond` is `false`.
+    *
+    * Analagous to munit.Assertions.assert.
+    *
+    * Only the condition is used. Clues are ignored.
+    *
+    * @param cond
+    * @param clue
+    *   ignored -- usage triggers the deprecation warning
+    * @return
+    *   Success iff cond is true. Failure otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.diff, which will automatically output clues",
+    ""
+  )
+  def assert(cond: => Boolean, clue: => Any): Result =
+    Result.assert(
+      cond
+    )
+
+  /** Fails the test with a failure Result when `cond` is `false`.
+    *
+    * @param cond
+    * @return
+    *   Success iff cond is true. Failure otherwise.
+    */
+  def assert(cond: => Boolean): Result = Result.assert(cond)
+
+  /** Fails the test if `obtained` and `expected` are non-equal using `==`.
+    *
+    * Analagous to munit.Assertions.assert.
+    *
+    * Only the obtained and expected values are used.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    * @param clue
+    *   Ignored -- Triggers deprecation warning
+    * @param ev
+    *   Evidence that A and B are of the same type for the comparison to be
+    *   valid.
+    * @return
+    *   Success iff obtained == expected. Failure otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.assertEquals, which will automatically output clues",
+    ""
+  )
+  def assertEquals[A, B](obtained: A, expected: B, clue: => Any)(implicit
+      ev: B <:< A
+  ): Result = assertEquals(obtained, expected)
+
+  /** Fails the test if `obtained` and `expected` are non-equal using `==`.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    *   The expected value
+    * @return
+    *   Success iff obtained == expected. Failure otherwise.
+    */
+  @nowarn
+  def assertEquals[A, B](obtained: A, expected: B)(implicit
+      ev: B <:< A
+  ): Result =
+    diff(obtained, expected)(_ == _)
+
+  /** Double specialized version of `HedgehogAssertions.assertEquals`.
+    *
+    * Asserts two double values are equal +- some error value.
+    *
+    * Analagous to munit.Assertions.assertEqualsDouble.
+    *
+    * Only the obtained, expected and delta parameters are used.
+    *
+    * @param obtained
+    *   The actual value.
+    * @param expected
+    *   The expected value.
+    * @param delta
+    *   The error allowed for double == comparison.
+    * @param clue
+    *   Ignored -- usage triggers a deprecation warning
+    * @return
+    *   Success iff obtained approximately equals expected +- delta. Failure
+    *   otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.diffDouble, which will automatically output clues",
+    ""
+  )
+  def assertEqualsDouble(
+      obtained: Double,
+      expected: Double,
+      delta: Double,
+      clue: => Any
+  ): Result = diffDouble(obtained, expected, delta)
+
+  /** Asserts two doubles are equal +- some erorr value.
+    *
+    * @param obtained
+    *   The actual value.
+    * @param expected
+    *   The expected value.
+    * @param delta
+    *   The error allowed for double == comparison. Default is 0.00.
+    * @return
+    *   Success iff obtained approximately equals expected +- delta. Failure
+    *   otherwis
+    */
+  def diffDouble(
+      obtained: Double,
+      expected: Double,
+      delta: Double = 0.00
+  ): Result =
+    diff(obtained, expected) { (a, b) =>
+      jl.Double.compare(expected, obtained) == 0 || Math.abs(
+        expected - obtained
+      ) <= delta
+    }
+
+  /** Float specialized version of assertEquals.
+    *
+    * Asserts two floats are equal within +- some error value.
+    *
+    * Analagous to munit.Assertions.assertEqualsFloat.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    *   The expected value
+    * @param delta
+    *   The error allowed for float == comparison.
+    * @param clue
+    *   Ignored -- usage triggers deprecation warning
+    * @return
+    *   Success iff obtained approximately equals expected +- delta. Failure
+    *   otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.diffFloat, which will automatically output clues",
+    ""
+  )
+  def assertEqualsFloat(
+      obtained: Float,
+      expected: Float,
+      delta: Float,
+      clue: => Any
+  ): Result = diffFloat(obtained, expected, delta)
+
+  /** Float specialized version of HedgehogAssertions.assertEquals.
+    *
+    * Asserts two floats are equal within +- some error value.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    *   The expected value
+    * @param delta
+    *   The error allowed for float == comparison. Default is 0.0f
+    * @return
+    *   Success iff obtained approximately equals expected +- delta. Failure
+    *   otherwise.
+    */
+  def diffFloat(obtained: Float, expected: Float, delta: Float = 0.0f): Result =
+    Result.diff(obtained, expected) { (a, b) =>
+      jl.Float.compare(a, b) == 0 || Math.abs(expected - obtained) <= delta
+    }
+
+  /** Asserts two strings are equal without outputting a diff.
+    *
+    * Analagous to munit.Assertions.assertNoDiff.
+    *
+    * @param obtained
+    *   The actual string
+    * @param expected
+    *   The expected string
+    * @param clue
+    *   Ignored -- usage triggers a deprecation warning
+    * @return
+    *   Success iff actual is obtained. Failure otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.diff, which will automatically output clues",
+    ""
+  )
+  def assertNoDiff(obtained: String, expected: String, clue: => Any): Result =
+    assertNoDiff(obtained, expected)
+
+  /** Asserts two strings are equal.
+    *
+    * @param obtained
+    *   The actual string
+    * @param expected
+    *   The expected value
+    * @return
+    *   Success iff actual is obtained. Failure otherwise.
+    */
+  def assertNoDiff(obtained: String, expected: String): Result = assert(
+    obtained == expected
+  )
+
+  /** Asserts obtained is not equal to expected using ==.
+    *
+    * Analagous to munit.Assertions.notEquals.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    *   The expected value
+    * @param clue
+    *   Ignored -- Usage triggers a deprecation warning
+    * @param ev
+    *   Evidence that obtained and expected are of the same type.
+    * @return
+    *   Success iff obtained != expected. Failure otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.assertNotEquals, which will automatically output clues",
+    ""
+  )
+  def assertNotEquals[A, B](obtained: A, expected: B, clue: => Any)(implicit
+      ev: A =:= B
+  ): Result = assertNotEquals(obtained, expected)
+
+  /** Asserts two values are nonequal.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    *   The expected value
+    * @param ev
+    *   Ensures that obtained and expected are of the same type.
+    * @return
+    *   Success iff obtained != actua.
+    */
+  @nowarn
+  def assertNotEquals[A, B](obtained: A, expected: B)(implicit
+      ev: A =:= B
+  ): Result = diff(obtained, expected)(_ != _)
+
+  /** Fails a test.
+    *
+    * Analagous to munit.Assertions.fail.
+    *
+    * @param message
+    *   The message to include in the failure.
+    * @param cause
+    *   An optional underlying exception to use as the cause of the failure.
+    * @return
+    *   Failure, always.
+    */
+  def fail(message: String, cause: Throwable): Result =
+    failure.log(hc.Error(new Exception(message, cause)))
+
+  /** Fails a test with the given message
+    *
+    * @param message
+    * @return
+    *   Failure, always.
+    */
+  def fail(message: String): Result =
+    failure.log(hc.Error(new Exception(message)))
+
+}

--- a/munit/shared/src/main/scala-2.12/hedgehog/munit/HedgehogSuite.scala
+++ b/munit/shared/src/main/scala-2.12/hedgehog/munit/HedgehogSuite.scala
@@ -1,0 +1,55 @@
+package hedgehog
+package munit
+
+import hedgehog.core.PropertyConfig
+import hedgehog.core.Seed
+import hedgehog.core.Status
+import hedgehog.{runner => hr}
+import _root_.munit.FunSuite
+import _root_.munit.Location
+
+abstract class HedgehogSuite extends FunSuite with HedgehogAssertions {
+
+  private val seedSource = hr.SeedSource.fromEnvOrTime()
+
+  private val seed: Seed = Seed.fromLong(seedSource.seed)
+
+  /** Runs a hedgehog property-based test.
+    *
+    * @see
+    *   hedgehog.runner.property
+    * @param name
+    * @param withConfig
+    *   A function with which to change the test PropertyConfig
+    * @param prop
+    *   The property under test
+    * @param loc
+    *   The location in the test suite source file
+    */
+  def property(
+      name: String,
+      withConfig: PropertyConfig => PropertyConfig = identity
+  )(
+      prop: => Property
+  )(implicit loc: Location): Unit = {
+    val t = hedgehog.runner.property(name, prop).config(withConfig)
+    test(name)(check(t, t.withConfig(PropertyConfig.default)))
+  }
+
+  private def check(test: hr.Test, config: PropertyConfig)(implicit
+      loc: Location
+  ): Any = {
+    val report = Property.check(test.withConfig(config), test.result, seed)
+    if (report.status != Status.ok) {
+      val reason = hr.Test.renderReport(
+        this.getClass.getName,
+        test,
+        report,
+        ansiCodesSupported = true
+      )
+      withMunitAssertions(assertions =>
+        assertions.fail(s"$reason\n${seedSource.renderLog}")
+      )
+    }
+  }
+}

--- a/munit/shared/src/main/scala-2.13+/hedgehog/munit/HedgehogAssertions.scala
+++ b/munit/shared/src/main/scala-2.13+/hedgehog/munit/HedgehogAssertions.scala
@@ -1,0 +1,382 @@
+package hedgehog
+package munit
+
+import hedgehog.{core => hc}
+import _root_.munit.Assertions
+
+import java.{lang => jl}
+
+/** Mirrors munit.Assertions assertions, allowing munit users to use familiar
+  * assertions while returning proper hedgehog.Result objects in property tests.
+  *
+  * Signatures don't line up exactly -- munit.Assertions is not F-bound
+  * polymorphic, so there is no way to align the signatures of the same
+  * argumentns with different return types in scala. We can, however, simply
+  * omit the implicit location arguments, because hedgehog.Result doesn't
+  * require munit.Location. Except in cases where Location is passed explicitly
+  * (which should be rare in user code), this should result in fairly easy
+  * adoption by munit and munit-scalacheck users.
+  */
+trait HedgehogAssertions { self: Assertions =>
+
+  /** Turns off hedgehog munit-like assertions, so users can use both property-
+    * and non-property- based-tests in their test suites. By using the passed
+    * assertions parameter, all the standard munit assertions that do not return
+    * unit are available, despite name ambiguities.
+    *
+    * ==Usage==
+    * {{{
+    *   test("1 + 1 is 2"){
+    *     withMunitAssertions{ assertions =>
+    *       assertEquals(1 + 1, 2)
+    *     }
+    *   }
+    * }}}
+    *
+    * @param body
+    *   a test body, taking an assertions parameter
+    * @return
+    */
+  def withMunitAssertions(body: => Assertions => Any): Any = body(
+    this.asInstanceOf[Assertions]
+  )
+
+  /** @see
+    *   hedgehog.core.Result.Failure
+    */
+  type Failure = Result.Failure
+
+  /** @see
+    *   hedgehog.core.Result.Success
+    */
+  type Success = Result.Success.type
+
+  /** Alias for Result.Success
+    *
+    * @see
+    *   hedgehog.core.Result.Success
+    */
+  lazy val Success: Success = Result.Success
+
+  /** Alias for Result.Failure
+    *
+    * @see
+    *   See hedgehog.core.Result.Failure
+    */
+  def Failure(log: List[hc.Log]) = Result.Failure(log)
+
+  /** Alias for Result.success
+    *
+    * @see
+    *   hedgehog.core.Result.success
+    */
+  def success = Result.success
+
+  /** Alias for Result.failure
+    *
+    * @see
+    *   hedgehog.core.Result.failure
+    */
+  def failure = Result.failure
+
+  /** Alias for Result.error
+    *
+    * @see
+    *   hedgehog.core.Result.error
+    */
+  def error(e: Exception) = Result.error(e)
+
+  /** Alias for Result.all
+    *
+    * @see
+    *   hedgehog.core.Result.all
+    */
+  def all(l: List[Result]) = Result.all(l)
+
+  /** Alias for Result.any
+    *
+    * @see
+    *   hedgehog.core.Result.any
+    */
+  def any(l: List[Result]) = Result.any(l)
+
+  /** Alias for Result.diff
+    *
+    * @see
+    *   hedgehog.core.Result.diff
+    */
+  def diff[A, B](a: A, b: B)(f: (A, B) => Boolean) = Result.diff(a, b)(f)
+
+  /** Alias for Result.diffNamed
+    *
+    * @see
+    *   hedgehog.core.Result.diffNamed
+    */
+  def diffNamed[A, B](logName: String, a: A, b: B)(f: (A, B) => Boolean) =
+    Result.diffNamed(logName, a, b)(f)
+
+  /** Fails the test with a failure Result when `cond` is `false`.
+    *
+    * Analagous to munit.Assertions.assert.
+    *
+    * Only the condition is used. Clues are ignored.
+    *
+    * @param cond
+    * @param clue
+    *   ignored -- usage triggers the deprecation warning
+    * @return
+    *   Success iff cond is true. Failure otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.diff, which will automatically output clues",
+    ""
+  )
+  def assert(cond: => Boolean, clue: => Any): Result =
+    Result.assert(
+      cond
+    )
+
+  /** Fails the test with a failure Result when `cond` is `false`.
+    *
+    * @param cond
+    * @return
+    *   Success iff cond is true. Failure otherwise.
+    */
+  def assert(cond: => Boolean): Result = Result.assert(cond)
+
+  /** Fails the test if `obtained` and `expected` are non-equal using `==`.
+    *
+    * Analagous to munit.Assertions.assert.
+    *
+    * Only the obtained and expected values are used.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    * @param clue
+    *   Ignored -- Triggers deprecation warning
+    * @param ev
+    *   Evidence that A and B are of the same type for the comparison to be
+    *   valid.
+    * @return
+    *   Success iff obtained == expected. Failure otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.assertEquals, which will automatically output clues",
+    ""
+  )
+  def assertEquals[A, B](obtained: A, expected: B, clue: => Any)(implicit
+      ev: B <:< A
+  ): Result = assertEquals(obtained, expected)
+
+  /** Fails the test if `obtained` and `expected` are non-equal using `==`.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    *   The expected value
+    * @return
+    *   Success iff obtained == expected. Failure otherwise.
+    */
+  def assertEquals[A, B](obtained: A, expected: B)(implicit
+      ev: B <:< A
+  ): Result =
+    diff(obtained, expected)(_ == _)
+
+  /** Double specialized version of `HedgehogAssertions.assertEquals`.
+    *
+    * Asserts two double values are equal +- some error value.
+    *
+    * Analagous to munit.Assertions.assertEqualsDouble.
+    *
+    * Only the obtained, expected and delta parameters are used.
+    *
+    * @param obtained
+    *   The actual value.
+    * @param expected
+    *   The expected value.
+    * @param delta
+    *   The error allowed for double == comparison.
+    * @param clue
+    *   Ignored -- usage triggers a deprecation warning
+    * @return
+    *   Success iff obtained approximately equals expected +- delta. Failure
+    *   otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.diffDouble, which will automatically output clues",
+    ""
+  )
+  def assertEqualsDouble(
+      obtained: Double,
+      expected: Double,
+      delta: Double,
+      clue: => Any
+  ): Result = diffDouble(obtained, expected, delta)
+
+  /** Asserts two doubles are equal +- some erorr value.
+    *
+    * @param obtained
+    *   The actual value.
+    * @param expected
+    *   The expected value.
+    * @param delta
+    *   The error allowed for double == comparison. Default is 0.00.
+    * @return
+    *   Success iff obtained approximately equals expected +- delta. Failure
+    *   otherwis
+    */
+  def diffDouble(
+      obtained: Double,
+      expected: Double,
+      delta: Double = 0.00
+  ): Result =
+    diff(obtained, expected) { (a, b) =>
+      jl.Double.compare(expected, obtained) == 0 || Math.abs(
+        expected - obtained
+      ) <= delta
+    }
+
+  /** Float specialized version of assertEquals.
+    *
+    * Asserts two floats are equal within +- some error value.
+    *
+    * Analagous to munit.Assertions.assertEqualsFloat.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    *   The expected value
+    * @param delta
+    *   The error allowed for float == comparison.
+    * @param clue
+    *   Ignored -- usage triggers deprecation warning
+    * @return
+    *   Success iff obtained approximately equals expected +- delta. Failure
+    *   otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.diffFloat, which will automatically output clues",
+    ""
+  )
+  def assertEqualsFloat(
+      obtained: Float,
+      expected: Float,
+      delta: Float,
+      clue: => Any
+  ): Result = diffFloat(obtained, expected, delta)
+
+  /** Float specialized version of HedgehogAssertions.assertEquals.
+    *
+    * Asserts two floats are equal within +- some error value.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    *   The expected value
+    * @param delta
+    *   The error allowed for float == comparison. Default is 0.0f
+    * @return
+    *   Success iff obtained approximately equals expected +- delta. Failure
+    *   otherwise.
+    */
+  def diffFloat(obtained: Float, expected: Float, delta: Float = 0.0f): Result =
+    Result.diff(obtained, expected) { (a, b) =>
+      jl.Float.compare(a, b) == 0 || Math.abs(expected - obtained) <= delta
+    }
+
+  /** Asserts two strings are equal without outputting a diff.
+    *
+    * Analagous to munit.Assertions.assertNoDiff.
+    *
+    * @param obtained
+    *   The actual string
+    * @param expected
+    *   The expected string
+    * @param clue
+    *   Ignored -- usage triggers a deprecation warning
+    * @return
+    *   Success iff actual is obtained. Failure otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.diff, which will automatically output clues",
+    ""
+  )
+  def assertNoDiff(obtained: String, expected: String, clue: => Any): Result =
+    assertNoDiff(obtained, expected)
+
+  /** Asserts two strings are equal.
+    *
+    * @param obtained
+    *   The actual string
+    * @param expected
+    *   The expected value
+    * @return
+    *   Success iff actual is obtained. Failure otherwise.
+    */
+  def assertNoDiff(obtained: String, expected: String): Result = assert(
+    obtained == expected
+  )
+
+  /** Asserts obtained is not equal to expected using ==.
+    *
+    * Analagous to munit.Assertions.notEquals.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    *   The expected value
+    * @param clue
+    *   Ignored -- Usage triggers a deprecation warning
+    * @param ev
+    *   Evidence that obtained and expected are of the same type.
+    * @return
+    *   Success iff obtained != expected. Failure otherwise.
+    */
+  @deprecated(
+    "Clues are unnecessary with hedgehog. Use HedgehogAssertions.assertNotEquals, which will automatically output clues",
+    ""
+  )
+  def assertNotEquals[A, B](obtained: A, expected: B, clue: => Any)(implicit
+      ev: A =:= B
+  ): Result = assertNotEquals(obtained, expected)
+
+  /** Asserts two values are nonequal.
+    *
+    * @param obtained
+    *   The actual value
+    * @param expected
+    *   The expected value
+    * @param ev
+    *   Ensures that obtained and expected are of the same type.
+    * @return
+    *   Success iff obtained != actua.
+    */
+  def assertNotEquals[A, B](obtained: A, expected: B)(implicit
+      ev: A =:= B
+  ): Result = diff(obtained, expected)(_ != _)
+
+  /** Fails a test.
+    *
+    * Analagous to munit.Assertions.fail.
+    *
+    * @param message
+    *   The message to include in the failure.
+    * @param cause
+    *   An optional underlying exception to use as the cause of the failure.
+    * @return
+    *   Failure, always.
+    */
+  def fail(message: String, cause: Throwable): Result =
+    failure.log(hc.Error(new Exception(message, cause)))
+
+  /** Fails a test with the given message
+    *
+    * @param message
+    * @return
+    *   Failure, always.
+    */
+  def fail(message: String): Result =
+    failure.log(hc.Error(new Exception(message)))
+
+}

--- a/munit/shared/src/main/scala-2.13+/hedgehog/munit/HedgehogSuite.scala
+++ b/munit/shared/src/main/scala-2.13+/hedgehog/munit/HedgehogSuite.scala
@@ -1,0 +1,55 @@
+package hedgehog
+package munit
+
+import hedgehog.core.PropertyConfig
+import hedgehog.core.Seed
+import hedgehog.core.Status
+import hedgehog.{runner => hr}
+import _root_.munit.FunSuite
+import _root_.munit.Location
+
+abstract class HedgehogSuite extends FunSuite with HedgehogAssertions {
+
+  private val seedSource = hr.SeedSource.fromEnvOrTime()
+
+  private val seed: Seed = Seed.fromLong(seedSource.seed)
+
+  /** Runs a hedgehog property-based test.
+    *
+    * @see
+    *   hedgehog.runner.property
+    * @param name
+    * @param withConfig
+    *   A function with which to change the test PropertyConfig
+    * @param prop
+    *   The property under test
+    * @param loc
+    *   The location in the test suite source file
+    */
+  def property(
+      name: String,
+      withConfig: PropertyConfig => PropertyConfig = identity
+  )(
+      prop: => Property
+  )(implicit loc: Location): Unit = {
+    val t = hedgehog.runner.property(name, prop).config(withConfig)
+    test(name)(check(t, t.withConfig(PropertyConfig.default)))
+  }
+
+  private def check(test: hr.Test, config: PropertyConfig)(implicit
+      loc: Location
+  ): Any = {
+    val report = Property.check(test.withConfig(config), test.result, seed)
+    if (report.status != Status.ok) {
+      val reason = hr.Test.renderReport(
+        this.getClass.getName,
+        test,
+        report,
+        ansiCodesSupported = true
+      )
+      withMunitAssertions(assertions =>
+        assertions.fail(s"$reason\n${seedSource.renderLog}")
+      )
+    }
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,3 +4,4 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.2" )
 addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.9.0")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
+


### PR DESCRIPTION
* Adds HedgehogAssertions for munit integrations

All `hedgehog.core.Result` methods are exposed on hedgehog.HedgehogAssertions

Assertions are munit assertion-like. They should make for easy migrations for
munit scalacheck users, and might make possible future scalafix migrations from
munit-scalacheck to munit-hedgehog a little easier.

* Adds HedgehogSuite extension to FunSuite
* Integrates HedgehogAssertions to make hedgehog usage easy for munit users.
* Provides `withoutHedgehogAssertions` to allow for name-ambiguous munit `Unit`
returning assertions instead of the `Result` returning HedgehogAssertions within
a `withoutHedgehogAssertions` block.
* Integrates the Hedgehog runner with munit's runner via the munit `fail`
mechanism
* provides HedgehogSuiteIntegrationTest demonstrating basic usage.

* Provides scaladoc documentation for all public members

* Assigns copyright to Hedgehog QA on all created files