### PR TITLE
deps: Use org.scala-native:test-interface-sbt-defs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,7 @@ lazy val sbtTest = crossProject(JVMPlatform, JSPlatform, NativePlatform)
         .cross(CrossVersion.for3Use2_13),
   )
   .nativeSettings(
-    libraryDependencies += "org.scala-native" %%% "test-interface" % nativeVersion
+    libraryDependencies += "org.scala-native" %%% "test-interface-sbt-defs" % nativeVersion
   )
   .dependsOn(core, runner)
 lazy val sbtTestJVM = sbtTest.jvm


### PR DESCRIPTION
See also https://github.com/scala-native/scala-native/issues/4844

## Problem
Testing frameworks should depend on Scala Native's test-interface-sbt-defs, not test-interface artifact.

Otherwise, this ends up causing eviction error in sbt 1.12.10.

## Solution
This switches out the dependency to test-interface-sbt-defs.